### PR TITLE
[Feat] #42 dailyMenuTable API 부분적 완료

### DIFF
--- a/EatSSU-iOS/EatSSU-iOS.xcodeproj/project.pbxproj
+++ b/EatSSU-iOS/EatSSU-iOS.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		7B906AF42A1B849D00E4B6A9 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B906AF32A1B849D00E4B6A9 /* MyPageViewController.swift */; };
 		7B9798AF2A24E6A70069F027 /* LunchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9798AE2A24E6A70069F027 /* LunchView.swift */; };
 		7B9798B12A24E6AE0069F027 /* DinnerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9798B02A24E6AE0069F027 /* DinnerView.swift */; };
+		7B9798B72A2638C50069F027 /* DailyMenuTableResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9798B62A2638C50069F027 /* DailyMenuTableResponse.swift */; };
 		7B98992E29E04F1300D1A076 /* ReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B98992D29E04F1300D1A076 /* ReviewViewController.swift */; };
 		7B9899A02A0B8F3E00D1A076 /* MenuTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B98999F2A0B8F3E00D1A076 /* MenuTableViewCell.swift */; };
 		7B9899A22A0B8FCF00D1A076 /* MenuHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9899A12A0B8FCF00D1A076 /* MenuHeaderView.swift */; };
@@ -121,6 +122,7 @@
 		7B906AF32A1B849D00E4B6A9 /* MyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
 		7B9798AE2A24E6A70069F027 /* LunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunchView.swift; sourceTree = "<group>"; };
 		7B9798B02A24E6AE0069F027 /* DinnerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DinnerView.swift; sourceTree = "<group>"; };
+		7B9798B62A2638C50069F027 /* DailyMenuTableResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyMenuTableResponse.swift; sourceTree = "<group>"; };
 		7B98992D29E04F1300D1A076 /* ReviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewViewController.swift; sourceTree = "<group>"; };
 		7B98999F2A0B8F3E00D1A076 /* MenuTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuTableViewCell.swift; sourceTree = "<group>"; };
 		7B9899A12A0B8FCF00D1A076 /* MenuHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuHeaderView.swift; sourceTree = "<group>"; };
@@ -544,6 +546,7 @@
 			isa = PBXGroup;
 			children = (
 				7BFD09BE2A21E6E400B40054 /* FixedMenuTableResponse.swift */,
+				7B9798B62A2638C50069F027 /* DailyMenuTableResponse.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -645,6 +648,7 @@
 				7B2C9E9329DAF9A70007603D /* SignUpViewController.swift in Sources */,
 				7B9899A42A0B902C00D1A076 /* MenuTableView.swift in Sources */,
 				7B9798B12A24E6AE0069F027 /* DinnerView.swift in Sources */,
+				7B9798B72A2638C50069F027 /* DailyMenuTableResponse.swift in Sources */,
 				7B2C9E9529DB359A0007603D /* MainTextField.swift in Sources */,
 				056956BB29C0D8BF002E8CF2 /* UIFont+.swift in Sources */,
 				7B2BBF9A299A1AC400EE0F1F /* HomeViewController.swift in Sources */,

--- a/EatSSU-iOS/EatSSU-iOS.xcodeproj/project.pbxproj
+++ b/EatSSU-iOS/EatSSU-iOS.xcodeproj/project.pbxproj
@@ -67,7 +67,7 @@
 		7BD73CD629D20B980076DC77 /* MorningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD73CD529D20B980076DC77 /* MorningView.swift */; };
 		7BD73CE629D2F9C60076DC77 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD73CE529D2F9C60076DC77 /* LoginViewController.swift */; };
 		7BD73CE829D2F9D10076DC77 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD73CE729D2F9D10076DC77 /* LoginView.swift */; };
-		7BFD09BF2A21E6E400B40054 /* MenuTableResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFD09BE2A21E6E400B40054 /* MenuTableResponse.swift */; };
+		7BFD09BF2A21E6E400B40054 /* FixedMenuTableResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFD09BE2A21E6E400B40054 /* FixedMenuTableResponse.swift */; };
 		7BFD09C12A21EE3E00B40054 /* HomeRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFD09C02A21EE3E00B40054 /* HomeRouter.swift */; };
 /* End PBXBuildFile section */
 
@@ -131,7 +131,7 @@
 		7BD73CD529D20B980076DC77 /* MorningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MorningView.swift; sourceTree = "<group>"; };
 		7BD73CE529D2F9C60076DC77 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		7BD73CE729D2F9D10076DC77 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
-		7BFD09BE2A21E6E400B40054 /* MenuTableResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuTableResponse.swift; sourceTree = "<group>"; };
+		7BFD09BE2A21E6E400B40054 /* FixedMenuTableResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedMenuTableResponse.swift; sourceTree = "<group>"; };
 		7BFD09C02A21EE3E00B40054 /* HomeRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRouter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -238,7 +238,6 @@
 			path = RateReview;
 			sourceTree = "<group>";
 		};
-
 		057A0B172A22252000F10B85 /* Auth */ = {
 			isa = PBXGroup;
 			children = (
@@ -256,31 +255,6 @@
 				057A0B222A22279B00F10B85 /* Token.swift */,
 			);
 			path = LocalDB;
-			sourceTree = "<group>";
-		};
-		05C5EBFD2A0BCC6500CC6A58 /* MyPage */ = {
-			isa = PBXGroup;
-			children = (
-				05C5EBFF2A0BCC8B00CC6A58 /* ViewController */,
-				05C5EBFE2A0BCC6E00CC6A58 /* View */,
-			);
-			path = MyPage;
-			sourceTree = "<group>";
-		};
-		05C5EBFE2A0BCC6E00CC6A58 /* View */ = {
-			isa = PBXGroup;
-			children = (
-				05EC82FF2A0BD40900851B55 /* NoticeTableViewCell.swift */,
-			);
-			path = View;
-			sourceTree = "<group>";
-		};
-		05C5EBFF2A0BCC8B00CC6A58 /* ViewController */ = {
-			isa = PBXGroup;
-			children = (
-				05C5EC002A0BCF2300CC6A58 /* NoticeViewController.swift */,
-			);
-			path = ViewController;
 			sourceTree = "<group>";
 		};
 		05C5EC022A0BCFCD00CC6A58 /* Model */ = {
@@ -569,7 +543,7 @@
 		7BFD09BD2A21E6CA00B40054 /* Home */ = {
 			isa = PBXGroup;
 			children = (
-				7BFD09BE2A21E6E400B40054 /* MenuTableResponse.swift */,
+				7BFD09BE2A21E6E400B40054 /* FixedMenuTableResponse.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -666,7 +640,6 @@
 				057A0B252A22284400F10B85 /* SignResponse.swift in Sources */,
 				057A0AC72A1B488B00F10B85 /* TotalReviewResponse.swift in Sources */,
 				057A0B212A22278800F10B85 /* RealmService.swift in Sources */,
-				05C5EC012A0BCF2300CC6A58 /* NoticeViewController.swift in Sources */,
 				05EC82FC2A0BD17F00851B55 /* NoticeModel.swift in Sources */,
 				7BD73CD629D20B980076DC77 /* MorningView.swift in Sources */,
 				7B2C9E9329DAF9A70007603D /* SignUpViewController.swift in Sources */,
@@ -703,10 +676,9 @@
 				7B2BBF96299A1AC400EE0F1F /* AppDelegate.swift in Sources */,
 				7B9899A62A0B904700D1A076 /* Menu.swift in Sources */,
 				7BFD09C12A21EE3E00B40054 /* HomeRouter.swift in Sources */,
-				7BFD09BF2A21E6E400B40054 /* MenuTableResponse.swift in Sources */,
+				7BFD09BF2A21E6E400B40054 /* FixedMenuTableResponse.swift in Sources */,
 				7B9899C32A154F9800D1A076 /* Config.swift in Sources */,
 				056956C729C0E350002E8CF2 /* ReviewRateView.swift in Sources */,
-				7B9899B72A0ED34300D1A076 /* MyPageViewController.swift in Sources */,
 				057A0B2D2A250C1E00F10B85 /* WriteReviewRouter.swift in Sources */,
 				7B906AF42A1B849D00E4B6A9 /* MyPageViewController.swift in Sources */,
 				7B2BBF98299A1AC400EE0F1F /* SceneDelegate.swift in Sources */,

--- a/EatSSU-iOS/EatSSU-iOS/Network/DTO/Home/DailyMenuTableResponse.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Network/DTO/Home/DailyMenuTableResponse.swift
@@ -1,0 +1,25 @@
+//
+//  NonFixedMenuTableResponse.swift
+//  EatSSU-iOS
+//
+//  Created by 최지우 on 2023/05/30.
+//
+
+import Foundation
+
+struct DailyMenuTableResponse: Codable {
+    let dailyMenuInfoList: [MenuInfoList]?
+    let flag: Int
+    
+    enum CodingKeys: String, CodingKey {
+            case dailyMenuInfoList = "menuInfoList"
+            case flag
+        }
+}
+
+struct MenuInfoList: Codable {
+    let menuId: Int
+    let name: String
+    let price: Int
+    let grade: Double?
+}

--- a/EatSSU-iOS/EatSSU-iOS/Network/DTO/Home/FixedMenuTableResponse.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Network/DTO/Home/FixedMenuTableResponse.swift
@@ -11,11 +11,11 @@ struct FixedMenuTableResponse: Codable {
     let menuInfoList: [MenuInfoList]?
 }
 
-struct MenuInfoList: Codable {
-    let menuId: Int
-    let name: String
-    let price: Int
-    let grade: Double
-}
+//struct MenuInfoList: Codable {
+//    let menuId: Int
+//    let name: String
+//    let price: Int
+//    let grade: Double?
+//}
 
 

--- a/EatSSU-iOS/EatSSU-iOS/Network/DTO/Home/FixedMenuTableResponse.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Network/DTO/Home/FixedMenuTableResponse.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct MenuTableResponse: Codable {
+struct FixedMenuTableResponse: Codable {
     let menuInfoList: [MenuInfoList]?
 }
 

--- a/EatSSU-iOS/EatSSU-iOS/Network/DTO/Home/FixedMenuTableResponse.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Network/DTO/Home/FixedMenuTableResponse.swift
@@ -11,11 +11,4 @@ struct FixedMenuTableResponse: Codable {
     let menuInfoList: [MenuInfoList]?
 }
 
-//struct MenuInfoList: Codable {
-//    let menuId: Int
-//    let name: String
-//    let price: Int
-//    let grade: Double?
-//}
-
 

--- a/EatSSU-iOS/EatSSU-iOS/Network/Router/HomeRouter.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Network/Router/HomeRouter.swift
@@ -9,7 +9,7 @@ import Foundation
 import Moya
 
 enum HomeRouter {
-    case getRestaurantMenu(restaurant: String)
+    case getFixedRestaurantMenu(restaurant: String) // getRestaurantMenu
 }
 
 extension HomeRouter: TargetType {
@@ -19,21 +19,21 @@ extension HomeRouter: TargetType {
 
     var path: String {
         switch self {
-        case .getRestaurantMenu:
+        case .getFixedRestaurantMenu:
             return "/menu"
         }
     }
 
     var method: Moya.Method {
         switch self {
-        case .getRestaurantMenu:
+        case .getFixedRestaurantMenu:
             return .get
         }
     }
 
     var task: Task {
         switch self {
-        case .getRestaurantMenu(let restaurant):
+        case .getFixedRestaurantMenu(let restaurant):
             return .requestParameters(parameters: ["restaurant": restaurant], encoding: URLEncoding.queryString)
         }
     }

--- a/EatSSU-iOS/EatSSU-iOS/Network/Router/HomeRouter.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Network/Router/HomeRouter.swift
@@ -6,45 +6,6 @@
 //
 
 import Foundation
-
-import Moya
-
-//enum HomeRouter {
-//    case morningMenuTable(menuId: String)
-//}
-//
-//extension HomeRouter: TargetType {
-//    var baseURL: URL {
-//        return URL (string: Config.baseURL)!
-//    }ㅔ
-//
-//    var path: String {
-//        switch self {
-//        case .morningMenuTable(let menuId):
-//            return "\(menuId)"
-//        }
-//    }
-//
-//    var method: Moya.Method {
-//        switch self {
-//        case .morningMenuTable:
-//            return .get
-//        }
-//    }
-//
-//    var task: Moya.Task {
-//        switch self {
-//        case .morningMenuTable:
-//            return .requestPlain
-//        }
-//    }
-//
-//    var headers: [String : String]? {
-//        return ["Content-Type":"application/json"]
-//    }
-//}
-
-import Foundation
 import Moya
 
 enum HomeRouter {

--- a/EatSSU-iOS/EatSSU-iOS/Network/Router/HomeRouter.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Network/Router/HomeRouter.swift
@@ -10,7 +10,10 @@ import Moya
 
 enum HomeRouter {
     case getFixedRestaurantMenu(restaurant: String)
-    case getDailyRestaurantMenu(date: String, restaurant: String)
+    case getDailyMorningRestaurantMenu(date: String, restaurant: String)
+    case getDailyLunchRestaurantMenu(date: String, restaurant: String)
+    case getDailyDinnerRestaurantMenu(date: String, restaurant: String)
+    
 }
 
 extension HomeRouter: TargetType {
@@ -22,8 +25,12 @@ extension HomeRouter: TargetType {
         switch self {
         case .getFixedRestaurantMenu:
             return "/menu"
-        case .getDailyRestaurantMenu(let date, _):
+        case .getDailyMorningRestaurantMenu(let date, _):
+            return "/menu/\(date)/morning"
+        case .getDailyLunchRestaurantMenu(let date, _):
             return "/menu/\(date)/lunch2"
+        case .getDailyDinnerRestaurantMenu(let date, _):
+            return "/menu/\(date)/dinner"
         }
     }
 
@@ -31,7 +38,11 @@ extension HomeRouter: TargetType {
         switch self {
         case .getFixedRestaurantMenu:
             return .get
-        case .getDailyRestaurantMenu:
+        case .getDailyMorningRestaurantMenu:
+            return .get
+        case .getDailyLunchRestaurantMenu:
+            return .get
+        case .getDailyDinnerRestaurantMenu:
             return .get
         }
     }
@@ -40,7 +51,11 @@ extension HomeRouter: TargetType {
         switch self {
         case .getFixedRestaurantMenu(let restaurant):
             return .requestParameters(parameters: ["restaurant": restaurant], encoding: URLEncoding.queryString)
-        case .getDailyRestaurantMenu(_, let restaurant):
+        case .getDailyMorningRestaurantMenu(_, let restaurant):
+            return .requestParameters(parameters: ["restaurant": restaurant], encoding: URLEncoding.queryString)
+        case .getDailyLunchRestaurantMenu(_, let restaurant):
+            return .requestParameters(parameters: ["restaurant": restaurant], encoding: URLEncoding.queryString)
+        case .getDailyDinnerRestaurantMenu(_, let restaurant):
             return .requestParameters(parameters: ["restaurant": restaurant], encoding: URLEncoding.queryString)
         }
     }

--- a/EatSSU-iOS/EatSSU-iOS/Network/Router/HomeRouter.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Network/Router/HomeRouter.swift
@@ -9,7 +9,8 @@ import Foundation
 import Moya
 
 enum HomeRouter {
-    case getFixedRestaurantMenu(restaurant: String) // getRestaurantMenu
+    case getFixedRestaurantMenu(restaurant: String)
+    case getDailyRestaurantMenu(date: String, restaurant: String)
 }
 
 extension HomeRouter: TargetType {
@@ -21,6 +22,8 @@ extension HomeRouter: TargetType {
         switch self {
         case .getFixedRestaurantMenu:
             return "/menu"
+        case .getDailyRestaurantMenu(let date, _):
+            return "/menu/\(date)/lunch2"
         }
     }
 
@@ -28,12 +31,16 @@ extension HomeRouter: TargetType {
         switch self {
         case .getFixedRestaurantMenu:
             return .get
+        case .getDailyRestaurantMenu:
+            return .get
         }
     }
 
     var task: Task {
         switch self {
         case .getFixedRestaurantMenu(let restaurant):
+            return .requestParameters(parameters: ["restaurant": restaurant], encoding: URLEncoding.queryString)
+        case .getDailyRestaurantMenu(_, let restaurant):
             return .requestParameters(parameters: ["restaurant": restaurant], encoding: URLEncoding.queryString)
         }
     }

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuTable/MenuTableViewCell.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuTable/MenuTableViewCell.swift
@@ -32,19 +32,25 @@ class MenuTableViewCell: UITableViewCell {
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        
+      
         contentView.addSubview(InfoTableStackView)
         
-        [nameLabel,priceLabel,ratingLabel].forEach {
-            $0.font = .medium(size: 14)
-        }
-        
+        setLabel()
         setLayout()
-        
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setLabel() {
+        nameLabel.do {
+            $0.numberOfLines = 0
+            $0.lineBreakMode = .byWordWrapping
+        }
+        [nameLabel,priceLabel,ratingLabel].forEach {
+            $0.font = .medium(size: 14)
+        }
     }
     
     func setLayout() {

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuView/DinnerView.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuView/DinnerView.swift
@@ -1,5 +1,5 @@
 //
-//  DinnerView.swift
+//  LunchView.swift
 //  EatSSU-iOS
 //
 //  Created by 최지우 on 2023/05/29.
@@ -15,8 +15,19 @@ class DinnerView: BaseUIView {
     
     //MARK: - Properties
     
-    let morningTableProvider = MoyaProvider<HomeRouter>()
-    var menuTableListDict = [Int: [MenuInfoList]]()
+    let dinnerMenuProvider = MoyaProvider<HomeRouter>()
+    var fixedMenuTableListDict = [Int: [MenuInfoList]]()
+    var dailyMenuTableListDict = [Int: [MenuInfoList]]()
+    let fixedMenuRestaurants: [String] = ["FOOD_COURT", "SNACK_CORNER", "THE_KITCHEN"] // 고정메뉴 레스토랑
+    let restaurantTags: [String: Int] = [
+        "DOMITORY": 1,
+        "DODAM": 2,
+        "HAKSIK": 3,
+        "FOOD_COURT": 4,
+        "SNACK_CORNER": 5,
+        "THE_KITCHEN": 6
+    ]
+  
 
     // MARK: - UI Components
     
@@ -239,9 +250,9 @@ class DinnerView: BaseUIView {
         super.init(frame: frame)
 
         setTableViewTagNumber()
-//        getMenuTableView()
         setupTableView()
-        
+        getMenuTableView()
+
     }
     
     required init?(coder: NSCoder) {
@@ -264,15 +275,13 @@ class DinnerView: BaseUIView {
         
         allRestaurantStackView.snp.makeConstraints {
             $0.top.equalToSuperview()
-                        $0.centerX.equalToSuperview()
-
+            $0.centerX.equalToSuperview()
         }
         
 //        [dormitoryStackView,dodamStackView,studentStackView,foodCourtStackView,snackCornerStackView,theKitchenStackView].forEach {
 //            $0.snp.makeConstraints {
 //                $0.horizontalEdges.equalToSuperview().inset(16)
 //                            $0.centerX.equalToSuperview()
-
 //            }
 //        }
     }
@@ -287,12 +296,11 @@ class DinnerView: BaseUIView {
     }
     
     func getMenuTableView() {
-        getMorningMenuTable(restaurant: "DOMITORY", tableView: dormitoryTableView)
-        getMorningMenuTable(restaurant: "DODAM", tableView: dodamTableView)
-        getMorningMenuTable(restaurant: "HAKSIK", tableView: studentTableView)
-        getMorningMenuTable(restaurant: "FOOD_COURT", tableView: foodCourtTableView)
-        getMorningMenuTable(restaurant: "SNACK_CORNER", tableView: snackCornerTableView)
-        getMorningMenuTable(restaurant: "THE_KITCHEN", tableView: theKitchenTableView)
+        getDailyDinnerMenuTable(date: "20230530", restaurant: "DODAM", tableView: dodamTableView)
+
+        getFixedDinnerMenuTable(restaurant: "FOOD_COURT", tableView: foodCourtTableView)
+        getFixedDinnerMenuTable(restaurant: "SNACK_CORNER", tableView: snackCornerTableView)
+        getFixedDinnerMenuTable(restaurant: "THE_KITCHEN", tableView: theKitchenTableView)
     }
     
     func setupTableView() {
@@ -306,30 +314,57 @@ class DinnerView: BaseUIView {
             $0.layer.borderWidth = 1.0
         }
     }
+    
+    func restaurantNameForTag(_ tag: Int) -> String? {
+        for (key, value) in restaurantTags {
+            if value == tag {
+                return key
+            }
+        }
+        return nil
+    }
 }
 
 extension DinnerView: UITableViewDataSource {
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return menuTableListDict[tableView.tag]?.count ?? 0
+        if tableView.tag > 3 {
+            if let menuTableList = fixedMenuTableListDict[tableView.tag] {
+                return menuTableList.count
+            }
+        } else {
+            return dailyMenuTableListDict.count
+        }
+        return 0
     }
-    
+
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: MenuTableViewCell.identifier, for: indexPath) as! MenuTableViewCell ?? MenuTableViewCell()
         
-        if let menuTableList = menuTableListDict[tableView.tag] {
-                let cellMenu: MenuInfoList = menuTableList[indexPath.row]
-                print("cell Menu: \(cellMenu)")
-
-                cell.menuIDLabel.text = "\(cellMenu.menuId)"
-                cell.nameLabel.text = cellMenu.name
-                cell.priceLabel.text = "\(cellMenu.price)"
-                cell.ratingLabel.text = "\(cellMenu.grade)"
+        if let restaurantName = restaurantNameForTag(tableView.tag) {
+            if fixedMenuRestaurants.contains(restaurantName) {
+                if let menuTableList = fixedMenuTableListDict[tableView.tag] {
+                    let cellMenu: MenuInfoList = menuTableList[indexPath.row]
+                    
+                    cell.nameLabel.text = cellMenu.name
+                    cell.priceLabel.text = "\(cellMenu.price)"
+                    cell.ratingLabel.text = "\(cellMenu.grade ?? 0)"
+                }
+            }else{
+                if tableView.tag == 2 {
+                    if let menuTableList = dailyMenuTableListDict[indexPath.row + 1] {// Non-fixed menus
+                        let cellMenuList: [MenuInfoList] = menuTableList
+                        
+                        cell.nameLabel.text = cellMenuList.map { $0.name }.joined(separator: "+")
+                        cell.priceLabel.text = "\(cellMenuList[0].price)"
+                        cell.ratingLabel.text = "\(cellMenuList[0].grade ?? 0)"
+                    }
+                }
             }
-        
-        cell.textLabel?.font = .regular(size: 14)
-        cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10)
-        cell.selectionStyle = .none     // 셀 선택 비활성화
-        
+            cell.textLabel?.font = .regular(size: 14)
+            cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10)
+            cell.selectionStyle = .none     // 셀 선택 비활성화
+        }
         return cell
     }
     
@@ -356,17 +391,39 @@ extension DinnerView: UISheetPresentationControllerDelegate {
 
 extension DinnerView {
     
-    func getMorningMenuTable(restaurant: String, tableView: UITableView) {
-        self.morningTableProvider.request(.getFixedRestaurantMenu(restaurant: restaurant)) { response in
+    func getFixedDinnerMenuTable(restaurant: String, tableView: UITableView) {
+        self.dinnerMenuProvider.request(.getFixedRestaurantMenu(restaurant: restaurant)) { response in
             switch response {
             case .success(let moyaResponse):
                 do {
                     print(moyaResponse.statusCode)
                     let responseDetailDto = try moyaResponse.map(FixedMenuTableResponse.self)
-                    self.menuTableListDict[tableView.tag] = responseDetailDto.menuInfoList
+                    self.fixedMenuTableListDict[tableView.tag] = responseDetailDto.menuInfoList
                     tableView.reloadData()
                     print(responseDetailDto)
-                    
+                } catch(let err) {
+                    print(err.localizedDescription)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+            }
+        }
+    }
+    func getDailyDinnerMenuTable(date: String, restaurant: String, tableView: UITableView) {
+        self.dinnerMenuProvider.request(.getDailyDinnerRestaurantMenu(date: date, restaurant: restaurant)) { response in
+            switch response {
+            case .success(let moyaResponse):
+                do {
+                    print(moyaResponse.statusCode)
+                    let responseDetailDto = try moyaResponse.map([DailyMenuTableResponse].self)
+                                    
+                    for menuTable in responseDetailDto {
+                        self.dailyMenuTableListDict[menuTable.flag] = menuTable.dailyMenuInfoList
+                    }
+                    DispatchQueue.main.async {
+                        tableView.reloadData()
+                    }
+                    print("responseDetailDto: \(responseDetailDto)")
                 } catch(let err) {
                     print(err.localizedDescription)
                 }
@@ -376,3 +433,4 @@ extension DinnerView {
         }
     }
 }
+

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuView/DinnerView.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuView/DinnerView.swift
@@ -297,10 +297,6 @@ class DinnerView: BaseUIView {
     
     func getMenuTableView() {
         getDailyDinnerMenuTable(date: "20230530", restaurant: "DODAM", tableView: dodamTableView)
-
-        getFixedDinnerMenuTable(restaurant: "FOOD_COURT", tableView: foodCourtTableView)
-        getFixedDinnerMenuTable(restaurant: "SNACK_CORNER", tableView: snackCornerTableView)
-        getFixedDinnerMenuTable(restaurant: "THE_KITCHEN", tableView: theKitchenTableView)
     }
     
     func setupTableView() {

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuView/DinnerView.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuView/DinnerView.swift
@@ -357,12 +357,12 @@ extension DinnerView: UISheetPresentationControllerDelegate {
 extension DinnerView {
     
     func getMorningMenuTable(restaurant: String, tableView: UITableView) {
-        self.morningTableProvider.request(.getRestaurantMenu(restaurant: restaurant)) { response in
+        self.morningTableProvider.request(.getFixedRestaurantMenu(restaurant: restaurant)) { response in
             switch response {
             case .success(let moyaResponse):
                 do {
                     print(moyaResponse.statusCode)
-                    let responseDetailDto = try moyaResponse.map(MenuTableResponse.self)
+                    let responseDetailDto = try moyaResponse.map(FixedMenuTableResponse.self)
                     self.menuTableListDict[tableView.tag] = responseDetailDto.menuInfoList
                     tableView.reloadData()
                     print(responseDetailDto)

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuView/LunchView.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuView/LunchView.swift
@@ -15,8 +15,8 @@ class LunchView: BaseUIView {
     
     //MARK: - Properties
     
-    let morningTableProvider = MoyaProvider<HomeRouter>()
-    var menuTableListDict = [Int: [MenuInfoList]]()
+    let fixedLunchMenuProvider = MoyaProvider<HomeRouter>()
+    var fixedMenuTableListDict = [Int: [MenuInfoList]]()
 
     // MARK: - UI Components
     
@@ -286,12 +286,12 @@ class LunchView: BaseUIView {
     }
     
     func getMenuTableView() {
-        getMorningMenuTable(restaurant: "DOMITORY", tableView: dormitoryTableView)
-        getMorningMenuTable(restaurant: "DODAM", tableView: dodamTableView)
-        getMorningMenuTable(restaurant: "HAKSIK", tableView: studentTableView)
-        getMorningMenuTable(restaurant: "FOOD_COURT", tableView: foodCourtTableView)
-        getMorningMenuTable(restaurant: "SNACK_CORNER", tableView: snackCornerTableView)
-        getMorningMenuTable(restaurant: "THE_KITCHEN", tableView: theKitchenTableView)
+        getFixedLunchMenuTable(restaurant: "DOMITORY", tableView: dormitoryTableView)
+        getFixedLunchMenuTable(restaurant: "DODAM", tableView: dodamTableView)
+        getFixedLunchMenuTable(restaurant: "HAKSIK", tableView: studentTableView)
+        getFixedLunchMenuTable(restaurant: "FOOD_COURT", tableView: foodCourtTableView)
+        getFixedLunchMenuTable(restaurant: "SNACK_CORNER", tableView: snackCornerTableView)
+        getFixedLunchMenuTable(restaurant: "THE_KITCHEN", tableView: theKitchenTableView)
     }
     
     func setupTableView() {
@@ -309,13 +309,13 @@ class LunchView: BaseUIView {
 
 extension LunchView: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return menuTableListDict[tableView.tag]?.count ?? 0
+        return fixedMenuTableListDict[tableView.tag]?.count ?? 0
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: MenuTableViewCell.identifier, for: indexPath) as! MenuTableViewCell ?? MenuTableViewCell()
         
-        if let menuTableList = menuTableListDict[tableView.tag] {
+        if let menuTableList = fixedMenuTableListDict[tableView.tag] {
                 let cellMenu: MenuInfoList = menuTableList[indexPath.row]
                 print("cell Menu: \(cellMenu)")
 
@@ -355,14 +355,14 @@ extension LunchView: UISheetPresentationControllerDelegate {
 
 extension LunchView {
     
-    func getMorningMenuTable(restaurant: String, tableView: UITableView) {
-        self.morningTableProvider.request(.getRestaurantMenu(restaurant: restaurant)) { response in
+    func getFixedLunchMenuTable(restaurant: String, tableView: UITableView) {
+        self.fixedLunchMenuProvider.request(.getFixedRestaurantMenu(restaurant: restaurant)) { response in
             switch response {
             case .success(let moyaResponse):
                 do {
                     print(moyaResponse.statusCode)
-                    let responseDetailDto = try moyaResponse.map(MenuTableResponse.self)
-                    self.menuTableListDict[tableView.tag] = responseDetailDto.menuInfoList
+                    let responseDetailDto = try moyaResponse.map(FixedMenuTableResponse.self)
+                    self.fixedMenuTableListDict[tableView.tag] = responseDetailDto.menuInfoList
                     tableView.reloadData()
                     print(responseDetailDto)
                     

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuView/LunchView.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuView/LunchView.swift
@@ -15,8 +15,19 @@ class LunchView: BaseUIView {
     
     //MARK: - Properties
     
-    let fixedLunchMenuProvider = MoyaProvider<HomeRouter>()
+    let lunchMenuProvider = MoyaProvider<HomeRouter>()
     var fixedMenuTableListDict = [Int: [MenuInfoList]]()
+    var dailyMenuTableListDict = [Int: [MenuInfoList]]()
+    let fixedMenuRestaurants: [String] = ["FOOD_COURT", "SNACK_CORNER", "THE_KITCHEN"] // 고정메뉴 레스토랑
+//    let restaurantTags: [String: Int] = [
+//        "DOMITORY": 1,
+//        "DODAM": 2,
+//        "HAKSIK": 3,
+//        "FOOD_COURT": 4,
+//        "SNACK_CORNER": 5,
+//        "THE_KITCHEN": 6
+//    ]
+  
 
     // MARK: - UI Components
     
@@ -239,8 +250,9 @@ class LunchView: BaseUIView {
         super.init(frame: frame)
 
         setTableViewTagNumber()
-        getMenuTableView()
         setupTableView()
+        getMenuTableView()
+
     }
     
     required init?(coder: NSCoder) {
@@ -263,8 +275,7 @@ class LunchView: BaseUIView {
         
         allRestaurantStackView.snp.makeConstraints {
             $0.top.equalToSuperview()
-                        $0.centerX.equalToSuperview()
-
+            $0.centerX.equalToSuperview()
         }
         
 //        [dormitoryStackView,dodamStackView,studentStackView,foodCourtStackView,snackCornerStackView,theKitchenStackView].forEach {
@@ -286,9 +297,8 @@ class LunchView: BaseUIView {
     }
     
     func getMenuTableView() {
-        getFixedLunchMenuTable(restaurant: "DOMITORY", tableView: dormitoryTableView)
-        getFixedLunchMenuTable(restaurant: "DODAM", tableView: dodamTableView)
-        getFixedLunchMenuTable(restaurant: "HAKSIK", tableView: studentTableView)
+        getDailyLunchMenuTable(date: "20230530", restaurant: "DODAM", tableView: dodamTableView)
+
         getFixedLunchMenuTable(restaurant: "FOOD_COURT", tableView: foodCourtTableView)
         getFixedLunchMenuTable(restaurant: "SNACK_CORNER", tableView: snackCornerTableView)
         getFixedLunchMenuTable(restaurant: "THE_KITCHEN", tableView: theKitchenTableView)
@@ -305,25 +315,92 @@ class LunchView: BaseUIView {
             $0.layer.borderWidth = 1.0
         }
     }
+    
+//    func restaurantNameForTag(_ tag: Int) -> String? {
+//        for (key, value) in restaurantTags {
+//            if value == tag {
+//                return key
+//            }
+//        }
+//        return nil
+//    }
+
 }
 
 extension LunchView: UITableViewDataSource {
+//    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+//        return fixedMenuTableListDict[tableView.tag]?.count ?? 0
+//    }
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return fixedMenuTableListDict[tableView.tag]?.count ?? 0
+        if tableView.tag > 3 {
+            if let menuTableList = fixedMenuTableListDict[tableView.tag] {
+                return menuTableList.count
+            }
+        } else {
+            // Non-fixed menus
+            // 아래의 코드는 모든 Non-fixed 메뉴 항목들의 수를 반환합니다.
+            // 만약 당신이 한 테이블 뷰에 모든 Non-fixed 메뉴를 보여주고 싶다면 이렇게 할 수 있습니다.
+//            var totalCount = 0
+//            for (_, menuTableList) in dailyMenuTableListDict {
+//                totalCount += menuTableList.flag
+//            }
+            print("totalCount: \(dailyMenuTableListDict.count)")
+            return dailyMenuTableListDict.count
+        }
+        return 0
     }
+
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: MenuTableViewCell.identifier, for: indexPath) as! MenuTableViewCell ?? MenuTableViewCell()
         
-        if let menuTableList = fixedMenuTableListDict[tableView.tag] {
-                let cellMenu: MenuInfoList = menuTableList[indexPath.row]
-                print("cell Menu: \(cellMenu)")
+        print("tag: \(tableView.tag)")
+        print("dailyMenuTableListDict: \(dailyMenuTableListDict)")
 
-                cell.menuIDLabel.text = "\(cellMenu.menuId)"
-                cell.nameLabel.text = cellMenu.name
-                cell.priceLabel.text = "\(cellMenu.price)"
-                cell.ratingLabel.text = "\(cellMenu.grade)"
+
+        // Use the tableView's tag to find restaurant name from the dictionary.
+//        if let restaurantName = restaurantNameForTag(tableView.tag) {
+//            print("restaurantName: \(restaurantName)")
+//
+//            // Check if this restaurant has fixed menus.
+//            if fixedMenuRestaurants.contains(restaurantName) {
+        if tableView.tag > 3  {
+                if let menuTableList = fixedMenuTableListDict[tableView.tag] {
+                    let cellMenu: MenuInfoList = menuTableList[indexPath.row]
+                    print("cell Menu: \(cellMenu)")
+                    
+                    //                        cell.menuIDLabel.text = "\(cellMenu.menuId)"
+                    cell.nameLabel.text = cellMenu.name
+                    cell.priceLabel.text = "\(cellMenu.price)"
+                    cell.ratingLabel.text = "\(cellMenu.grade ?? 0)"
+                }
+        }else if tableView.tag == 2 {
+            if let menuTableList = dailyMenuTableListDict[indexPath.row + 1] {// Non-fixed menus
+                print("dailyMenuTableListDictt: \(menuTableList)")
+                
+                
+                //            if let menuTableList = dailyMenuTableListDict[indexPath.row + 1] {
+                let cellMenuList: [MenuInfoList] = menuTableList
+                print("cell Menu: \(cellMenuList)")
+                
+                cell.nameLabel.text = cellMenuList.map { $0.name }.joined(separator: "+")
+                cell.priceLabel.text = "\(cellMenuList[0].price)"
+                cell.ratingLabel.text = "\(cellMenuList[0].grade ?? 0)"
             }
+        }
+        
+//            return cell
+//        ///
+//
+//        if let menuTableList = fixedMenuTableListDict[tableView.tag] {
+//                let cellMenu: MenuInfoList = menuTableList[indexPath.row]
+//                print("cell Menu: \(cellMenu)")
+//
+//                cell.menuIDLabel.text = "\(cellMenu.menuId)"
+//                cell.nameLabel.text = cellMenu.name
+//                cell.priceLabel.text = "\(cellMenu.price)"
+//                cell.ratingLabel.text = "\(cellMenu.grade)"
+            
         
         cell.textLabel?.font = .regular(size: 14)
         cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10)
@@ -356,7 +433,7 @@ extension LunchView: UISheetPresentationControllerDelegate {
 extension LunchView {
     
     func getFixedLunchMenuTable(restaurant: String, tableView: UITableView) {
-        self.fixedLunchMenuProvider.request(.getFixedRestaurantMenu(restaurant: restaurant)) { response in
+        self.lunchMenuProvider.request(.getFixedRestaurantMenu(restaurant: restaurant)) { response in
             switch response {
             case .success(let moyaResponse):
                 do {
@@ -365,7 +442,33 @@ extension LunchView {
                     self.fixedMenuTableListDict[tableView.tag] = responseDetailDto.menuInfoList
                     tableView.reloadData()
                     print(responseDetailDto)
+                } catch(let err) {
+                    print(err.localizedDescription)
+                }
+            case .failure(let err):
+                print(err.localizedDescription)
+            }
+        }
+    }
+    func getDailyLunchMenuTable(date: String, restaurant: String, tableView: UITableView) {
+        self.lunchMenuProvider.request(.getDailyRestaurantMenu(date: date, restaurant: restaurant)) { response in
+            switch response {
+            case .success(let moyaResponse):
+                do {
+                    print(moyaResponse.statusCode)
+                    let responseDetailDto = try moyaResponse.map([DailyMenuTableResponse].self)
+                                    
+                    for menuTable in responseDetailDto {
+                        self.dailyMenuTableListDict[menuTable.flag] = menuTable.dailyMenuInfoList
+                    }
+//                    print("menuTable.dailyMenuInfoList: \(self.dailyMenuTableListDict[1])")
+
+                    tableView.reloadData()
                     
+//                    DispatchQueue.main.async {
+//                        tableView.reloadData()
+//                    }
+                    print("responseDetailDto: \(responseDetailDto)")
                 } catch(let err) {
                     print(err.localizedDescription)
                 }

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuView/LunchView.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuView/LunchView.swift
@@ -19,14 +19,14 @@ class LunchView: BaseUIView {
     var fixedMenuTableListDict = [Int: [MenuInfoList]]()
     var dailyMenuTableListDict = [Int: [MenuInfoList]]()
     let fixedMenuRestaurants: [String] = ["FOOD_COURT", "SNACK_CORNER", "THE_KITCHEN"] // 고정메뉴 레스토랑
-//    let restaurantTags: [String: Int] = [
-//        "DOMITORY": 1,
-//        "DODAM": 2,
-//        "HAKSIK": 3,
-//        "FOOD_COURT": 4,
-//        "SNACK_CORNER": 5,
-//        "THE_KITCHEN": 6
-//    ]
+    let restaurantTags: [String: Int] = [
+        "DOMITORY": 1,
+        "DODAM": 2,
+        "HAKSIK": 3,
+        "FOOD_COURT": 4,
+        "SNACK_CORNER": 5,
+        "THE_KITCHEN": 6
+    ]
   
 
     // MARK: - UI Components
@@ -282,7 +282,6 @@ class LunchView: BaseUIView {
 //            $0.snp.makeConstraints {
 //                $0.horizontalEdges.equalToSuperview().inset(16)
 //                            $0.centerX.equalToSuperview()
-
 //            }
 //        }
     }
@@ -316,96 +315,56 @@ class LunchView: BaseUIView {
         }
     }
     
-//    func restaurantNameForTag(_ tag: Int) -> String? {
-//        for (key, value) in restaurantTags {
-//            if value == tag {
-//                return key
-//            }
-//        }
-//        return nil
-//    }
-
+    func restaurantNameForTag(_ tag: Int) -> String? {
+        for (key, value) in restaurantTags {
+            if value == tag {
+                return key
+            }
+        }
+        return nil
+    }
 }
 
 extension LunchView: UITableViewDataSource {
-//    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-//        return fixedMenuTableListDict[tableView.tag]?.count ?? 0
-//    }
+
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if tableView.tag > 3 {
             if let menuTableList = fixedMenuTableListDict[tableView.tag] {
                 return menuTableList.count
             }
         } else {
-            // Non-fixed menus
-            // 아래의 코드는 모든 Non-fixed 메뉴 항목들의 수를 반환합니다.
-            // 만약 당신이 한 테이블 뷰에 모든 Non-fixed 메뉴를 보여주고 싶다면 이렇게 할 수 있습니다.
-//            var totalCount = 0
-//            for (_, menuTableList) in dailyMenuTableListDict {
-//                totalCount += menuTableList.flag
-//            }
-            print("totalCount: \(dailyMenuTableListDict.count)")
             return dailyMenuTableListDict.count
         }
         return 0
     }
 
-    
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: MenuTableViewCell.identifier, for: indexPath) as! MenuTableViewCell ?? MenuTableViewCell()
         
-        print("tag: \(tableView.tag)")
-        print("dailyMenuTableListDict: \(dailyMenuTableListDict)")
-
-
-        // Use the tableView's tag to find restaurant name from the dictionary.
-//        if let restaurantName = restaurantNameForTag(tableView.tag) {
-//            print("restaurantName: \(restaurantName)")
-//
-//            // Check if this restaurant has fixed menus.
-//            if fixedMenuRestaurants.contains(restaurantName) {
-        if tableView.tag > 3  {
+        if let restaurantName = restaurantNameForTag(tableView.tag) {
+            if fixedMenuRestaurants.contains(restaurantName) {
                 if let menuTableList = fixedMenuTableListDict[tableView.tag] {
                     let cellMenu: MenuInfoList = menuTableList[indexPath.row]
-                    print("cell Menu: \(cellMenu)")
                     
-                    //                        cell.menuIDLabel.text = "\(cellMenu.menuId)"
                     cell.nameLabel.text = cellMenu.name
                     cell.priceLabel.text = "\(cellMenu.price)"
                     cell.ratingLabel.text = "\(cellMenu.grade ?? 0)"
                 }
-        }else if tableView.tag == 2 {
-            if let menuTableList = dailyMenuTableListDict[indexPath.row + 1] {// Non-fixed menus
-                print("dailyMenuTableListDictt: \(menuTableList)")
-                
-                
-                //            if let menuTableList = dailyMenuTableListDict[indexPath.row + 1] {
-                let cellMenuList: [MenuInfoList] = menuTableList
-                print("cell Menu: \(cellMenuList)")
-                
-                cell.nameLabel.text = cellMenuList.map { $0.name }.joined(separator: "+")
-                cell.priceLabel.text = "\(cellMenuList[0].price)"
-                cell.ratingLabel.text = "\(cellMenuList[0].grade ?? 0)"
+            }else{
+                if tableView.tag == 2 {
+                    if let menuTableList = dailyMenuTableListDict[indexPath.row + 1] {// Non-fixed menus
+                        let cellMenuList: [MenuInfoList] = menuTableList
+                        
+                        cell.nameLabel.text = cellMenuList.map { $0.name }.joined(separator: "+")
+                        cell.priceLabel.text = "\(cellMenuList[0].price)"
+                        cell.ratingLabel.text = "\(cellMenuList[0].grade ?? 0)"
+                    }
+                }
             }
+            cell.textLabel?.font = .regular(size: 14)
+            cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10)
+            cell.selectionStyle = .none     // 셀 선택 비활성화
         }
-        
-//            return cell
-//        ///
-//
-//        if let menuTableList = fixedMenuTableListDict[tableView.tag] {
-//                let cellMenu: MenuInfoList = menuTableList[indexPath.row]
-//                print("cell Menu: \(cellMenu)")
-//
-//                cell.menuIDLabel.text = "\(cellMenu.menuId)"
-//                cell.nameLabel.text = cellMenu.name
-//                cell.priceLabel.text = "\(cellMenu.price)"
-//                cell.ratingLabel.text = "\(cellMenu.grade)"
-            
-        
-        cell.textLabel?.font = .regular(size: 14)
-        cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10)
-        cell.selectionStyle = .none     // 셀 선택 비활성화
-        
         return cell
     }
     
@@ -461,13 +420,9 @@ extension LunchView {
                     for menuTable in responseDetailDto {
                         self.dailyMenuTableListDict[menuTable.flag] = menuTable.dailyMenuInfoList
                     }
-//                    print("menuTable.dailyMenuInfoList: \(self.dailyMenuTableListDict[1])")
-
-                    tableView.reloadData()
-                    
-//                    DispatchQueue.main.async {
-//                        tableView.reloadData()
-//                    }
+                    DispatchQueue.main.async {
+                        tableView.reloadData()
+                    }
                     print("responseDetailDto: \(responseDetailDto)")
                 } catch(let err) {
                     print(err.localizedDescription)

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuView/LunchView.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuView/LunchView.swift
@@ -410,7 +410,7 @@ extension LunchView {
         }
     }
     func getDailyLunchMenuTable(date: String, restaurant: String, tableView: UITableView) {
-        self.lunchMenuProvider.request(.getDailyRestaurantMenu(date: date, restaurant: restaurant)) { response in
+        self.lunchMenuProvider.request(.getDailyLunchRestaurantMenu(date: date, restaurant: restaurant)) { response in
             switch response {
             case .success(let moyaResponse):
                 do {

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuView/MorningView.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuView/MorningView.swift
@@ -297,10 +297,6 @@ class MorningView: BaseUIView {
     
     func getMenuTableView() {
         getDailyMorningMenuTable(date: "20230530", restaurant: "DODAM", tableView: dodamTableView)
-
-        getFixedMorningMenuTable(restaurant: "FOOD_COURT", tableView: foodCourtTableView)
-        getFixedMorningMenuTable(restaurant: "SNACK_CORNER", tableView: snackCornerTableView)
-        getFixedMorningMenuTable(restaurant: "THE_KITCHEN", tableView: theKitchenTableView)
     }
     
     func setupTableView() {

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuView/MorningView.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/MenuView/MorningView.swift
@@ -356,12 +356,12 @@ extension MorningView: UISheetPresentationControllerDelegate {
 extension MorningView {
     
     func getMorningMenuTable(restaurant: String, tableView: UITableView) {
-        self.morningTableProvider.request(.getRestaurantMenu(restaurant: restaurant)) { response in
+        self.morningTableProvider.request(.getFixedRestaurantMenu(restaurant: restaurant)) { response in
             switch response {
             case .success(let moyaResponse):
                 do {
                     print(moyaResponse.statusCode)
-                    let responseDetailDto = try moyaResponse.map(MenuTableResponse.self)
+                    let responseDetailDto = try moyaResponse.map(FixedMenuTableResponse.self)
                     self.menuTableListDict[tableView.tag] = responseDetailDto.menuInfoList
                     tableView.reloadData()
                     print(responseDetailDto)

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Home/ViewController/HomeViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Home/ViewController/HomeViewController.swift
@@ -21,6 +21,7 @@ class HomeViewController: TabmanViewController {
     // MARK: - UI Components
     
     let morningView = MorningView()
+    let lunchView = LunchView()
         
     private let contentView = UIView()
     public let bar = TMBar.ButtonBar()
@@ -114,13 +115,18 @@ class HomeViewController: TabmanViewController {
         self.navigationController?.pushViewController(nextVC, animated: true)
     }
 
+    // FIXME: date 전달
     @objc func didSelectedDate(_ sender: UIDatePicker) {
         let dateFormatter = DateFormatter()
         dateFormatter.dateStyle = .medium
         dateFormatter.timeStyle = .none
         dateFormatter.dateFormat = "yyyy.MM.dd"
         dateSelectedField.text = dateFormatter.string(from: sender.date)
+//        dateFormatter.dateFormat = "yyyyMMdd"
+//        let dailyDate = dateFormatter.string(from: sender.date)
         view.endEditing(true)
+        
+//        lunchView.getDailyLunchMenuTable(date: dailyDate, restaurant: "DODAM", tableView: lunchView.dodamTableView)
     }
 }
 


### PR DESCRIPTION
## 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 유동 메뉴 API 부분적으로 완료하였습니다.

## 작업 사항

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- morning/dinner는 아직 DB가 없어, LunchView의 DODAM 테이블로 유동메뉴 확인하시면 됩니다.
- 고정메뉴는 lunch만 해당됩니다.
- date 클릭 시, 로직은 아직 미완입니다.

## 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| HomeView | ![image](https://github.com/EAT-SSU/EatSSU-iOS/assets/102797359/d385628b-8a33-486c-a7a0-970fdecab605) |

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #42