### PR TITLE
[Refactor] login UI layout

### DIFF
--- a/EatSSU-iOS/EatSSU-iOS/Global/Extension/UIColor+.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Global/Extension/UIColor+.swift
@@ -40,6 +40,10 @@ extension UIColor {
     static var primary: UIColor {
         return UIColor(hex: "#DF5757")
     }
+    
+    static var kakaoYellow: UIColor {
+        return UIColor(hex: "#FEE500")
+    }
 }
 
 extension UIColor {

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Auth/View/NewLoginView.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Auth/View/NewLoginView.swift
@@ -20,20 +20,22 @@ class NewLoginView: BaseUIView {
         $0.addTitleAttribute(title: TextLiteral.signInWithApple, titleColor: .black, fontName: .regular(size: 18))
         $0.setImage(ImageLiteral.appleIcon, for: .normal)
         $0.setRoundBorder(borderColor: .black, borderWidth: 1.0, cornerRadius: 5.0)
-        $0.imageEdgeInsets = .init(top: 0, left: 0, bottom: 0, right: 200)
-        $0.contentEdgeInsets = .init(top: 10, left: 0, bottom: 10, right: 0)
+        $0.imageEdgeInsets = .init(top: -12, left: 0, bottom: -4, right: 190)
+        $0.contentEdgeInsets = .init(top: 0, left: -16, bottom: -4, right: 0)
     }
     
     private let kakaoLoginButton = UIButton().then {
         $0.addTitleAttribute(title: TextLiteral.signInWithKakao, titleColor: .black, fontName: .regular(size: 18))
-        $0.backgroundColor = .yellow
+        $0.backgroundColor = .kakaoYellow
         $0.contentEdgeInsets = .init(top: 10, left: 0, bottom: 10, right: 0)
+        $0.layer.cornerRadius = 5.0
     }
     
     private let lookingButton = UIButton().then {
         $0.addTitleAttribute(title: TextLiteral.lookingWithNoSignIn, titleColor: .black, fontName: .regular(size: 18))
         $0.backgroundColor = .gray100
         $0.contentEdgeInsets = .init(top: 10, left: 0, bottom: 10, right: 0)
+        $0.layer.cornerRadius = 5.0
     }
     
     private let buttonSelectView = UIView()

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Auth/View/NewLoginView.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Auth/View/NewLoginView.swift
@@ -48,25 +48,29 @@ class NewLoginView: BaseUIView {
     
     override func setLayout() {
         logoImage.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(UIScreen.main.bounds.height / 3.9)
+            $0.top.equalToSuperview()
             $0.leading.trailing.equalToSuperview().inset(86)
+            $0.height.equalTo(194)
         }
         buttonSelectView.snp.makeConstraints {
-            $0.top.equalTo(logoImage.snp.bottom).offset(160)
             $0.leading.trailing.equalToSuperview().inset(16)
-            $0.bottom.equalToSuperview().offset(-(UIScreen.main.bounds.height / 3.5))
+            $0.bottom.equalToSuperview()
+            $0.height.equalToSuperview().multipliedBy(1/3.1)
         }
         appleLoginButton.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview()
             $0.top.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(44)
         }
         kakaoLoginButton.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview()
             $0.top.equalTo(appleLoginButton.snp.bottom).offset(16)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(44)
         }
         lookingButton.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview()
             $0.top.equalTo(kakaoLoginButton.snp.bottom).offset(16)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(44)
         }
     }
 }

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Auth/View/SetNickNameView.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Auth/View/SetNickNameView.swift
@@ -61,12 +61,12 @@ class SetNickNameView: BaseUIView {
     
     override func setLayout() {
         setNickNameStackView.snp.makeConstraints {
-            $0.top.equalToSuperview().offset(UIScreen.main.bounds.height / 7.5)
+            $0.top.equalToSuperview()
             $0.leading.trailing.equalToSuperview().inset(16)
         }
         completeSettingNickNameButton.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(16)
-            $0.bottom.equalToSuperview().offset(-(UIScreen.main.bounds.height / 13.8))
+            $0.bottom.equalToSuperview()
             $0.height.equalTo(40)
         }
     }

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Auth/ViewController/NewLoginViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Auth/ViewController/NewLoginViewController.swift
@@ -24,7 +24,9 @@ class NewLoginViewController: BaseViewController {
     
     override func setLayout() {
         loginView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.top.equalToSuperview().offset(UIScreen.main.bounds.height / 4.0)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottomMargin).inset(50)
         }
     }
 }

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Auth/ViewController/SetNickNameViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Auth/ViewController/SetNickNameViewController.swift
@@ -24,7 +24,9 @@ class SetNickNameViewController: BaseViewController {
     
     override func setLayout() {
         setNickNameView.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+            $0.top.equalTo(view.safeAreaLayoutGuide.snp.topMargin).inset(25)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottomMargin).inset(27)
         }
     }
     


### PR DESCRIPTION
## 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- login UI layout 리팩터링

## 작업 사항

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- issue 번호를 잘못 달아, local 상에서는 수정되었다고 뜨는데 rebase...remote... 계속 에러나서 그냥 할께요...
<img width="566" alt="image" src="https://github.com/EAT-SSU/EatSSU-iOS/assets/102797359/7753a095-85ab-40eb-b90a-7a60183bac08">

- 리뷰 단 부분 레이아웃 수정했습니다.
   - `$0.top.equalToSuperview().offset(UIScreen.main.bounds.height / 4.0)` 이 부분은 레이아웃이 깨져 이렇게 갈께요.
- 카카오 버튼 색상 변경했고, 아이콘은 아직 없어 추후 추가하겠습니다.
   
 - ⁉️ UIColor+ 에서 background, tableGray 는 사용하는 건가요 (⬅️ 사용안하면 지울께여!)

## 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
|  로그인 화면 | <img width="385" alt="image" src="https://github.com/EAT-SSU/EatSSU-iOS/assets/102797359/7193aa2b-10cc-409f-bc17-74e9186ab9fe"> |

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #54
