### PR TITLE
[Feat] #63 메인 식당 테이블 reload 시 이전 데이터와 충돌 해결 

### DIFF
--- a/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/HomeRestaurantView.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/HomeRestaurantView.swift
@@ -17,7 +17,7 @@ class HomeRestaurantView: BaseUIView {
     
     private var currentRestaurant = ""
     let menuProvider = MoyaProvider<HomeRouter>()
-    private var changedMenuData: [ChangeMenuTableResponse] = [] {
+    private var changedMenuData: [String: [ChangeMenuTableResponse]] = [:] {
         didSet {
             switch currentRestaurant {
             case "DODAM":
@@ -253,7 +253,7 @@ class HomeRestaurantView: BaseUIView {
 extension HomeRestaurantView: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if tableView.tag < 4 {
-            return changedMenuData.count
+            return changedMenuData[currentRestaurant]?.count ?? 0
         } else {
             return fixedMenuData?.fixMenuInfoList?.count ?? 0
         }
@@ -267,7 +267,7 @@ extension HomeRestaurantView: UITableViewDataSource {
             if(indexPath.row > changedMenuData.count-1) {
                 return MenuTableViewCell()
             } else {
-                cell.bind(menuData: changedMenuData[indexPath.row])
+                cell.bind(menuData: changedMenuData[currentRestaurant]?[indexPath.row])
             }
             
         } else {
@@ -314,7 +314,7 @@ extension HomeRestaurantView {
                     print(moyaResponse.statusCode)
             
                     let responseDetailDto = try moyaResponse.map([ChangeMenuTableResponse].self)
-                    self.changedMenuData = responseDetailDto
+                    self.changedMenuData[restaurant] = responseDetailDto
                 } catch(let err) {
                     print(err.localizedDescription)
                 }


### PR DESCRIPTION
## 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 메인 식당 테이블 reload 시 이전 데이터와 충돌 해결 못하고 우선적으로 머지합니다
- 우선 순위 높은 것부터 작업 후, 다시 해결하겠습니다.

## 작업 사항

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 점심 탭바에서 날짜를 바꿀 경우 점심 테이블의 메뉴는 제대로 나오는데, 아침/저녁은 아래의 이미지와 같은 현상이 발생하는 상황입니다.
- changedMenuData 딕셔너리(`changedMenuData: [String: [ChangeMenuTableResponse]] = [:]`)로 변경하여 분기처리를 해주었는데 똑같아요...🥹
- 스크롤 시 발생하는 문제가 아니라 cell 재사용에 대한 문제는 고려해보지 않았는데 한 번 생각해보겠습니다...

## 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 메인 뷰 | <img width="320" alt="스크린샷 2023-07-25 오후 4 51 19" src="https://github.com/EAT-SSU/EatSSU-iOS/assets/102797359/7b97afba-8b48-4e77-8b2e-ce1c43029d1c"> |


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #63 
