### PR TITLE
[Feat] #74 메뉴 테이블 cell 클릭 시, API 호출을 위해 필요한 데이터를 전달하는 로직 구현

### DIFF
--- a/EatSSU-iOS/EatSSU-iOS.xcodeproj/project.pbxproj
+++ b/EatSSU-iOS/EatSSU-iOS.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		7BBD4CC32A70FA4A00515F67 /* ChangeNicknameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD4CC22A70FA4A00515F67 /* ChangeNicknameViewController.swift */; };
 		7BBD4CCB2A72541500515F67 /* MyReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD4CCA2A72541500515F67 /* MyReviewViewController.swift */; };
 		7BBD4CCD2A72544E00515F67 /* MyReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD4CCC2A72544E00515F67 /* MyReviewView.swift */; };
+		7BBD4CF52A765A3000515F67 /* MenuTypeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD4CF42A765A3000515F67 /* MenuTypeInfo.swift */; };
 		7BD73CD429D208940076DC77 /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = 7BD73CD329D208940076DC77 /* Then */; };
 		7BD73CE629D2F9C60076DC77 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD73CE529D2F9C60076DC77 /* LoginViewController.swift */; };
 		7BD73CE829D2F9D10076DC77 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD73CE729D2F9D10076DC77 /* LoginView.swift */; };
@@ -184,6 +185,7 @@
 		7BBD4CC22A70FA4A00515F67 /* ChangeNicknameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeNicknameViewController.swift; sourceTree = "<group>"; };
 		7BBD4CCA2A72541500515F67 /* MyReviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyReviewViewController.swift; sourceTree = "<group>"; };
 		7BBD4CCC2A72544E00515F67 /* MyReviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyReviewView.swift; sourceTree = "<group>"; };
+		7BBD4CF42A765A3000515F67 /* MenuTypeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuTypeInfo.swift; sourceTree = "<group>"; };
 		7BD73CE529D2F9C60076DC77 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		7BD73CE729D2F9D10076DC77 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		7BF5CC0B2A497AD800E4EE11 /* NewLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewLoginView.swift; sourceTree = "<group>"; };
@@ -494,6 +496,7 @@
 				7B51C5A62A63C7230016B418 /* ChangeMenuInfoModel.swift */,
 				7B51C5BC2A654FB40016B418 /* FixedMenuInfoModel.swift */,
 				7BBD4CA92A6D3B7A00515F67 /* TimeData.swift */,
+				7BBD4CF42A765A3000515F67 /* MenuTypeInfo.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -795,6 +798,7 @@
 				7B51C5932A628FB30016B418 /* HomeViewController.swift in Sources */,
 				7BBD4CAA2A6D3B7A00515F67 /* TimeData.swift in Sources */,
 				7BBD4C972A67DAEF00515F67 /* ChangeMenuTableResponse.swift in Sources */,
+				7BBD4CF52A765A3000515F67 /* MenuTypeInfo.swift in Sources */,
 				058326662A4D97BC004A295F /* UICollectionViewCell+.swift in Sources */,
 				7B2BBFB2299A29AF00EE0F1F /* UIColor+.swift in Sources */,
 				056956BF29C0DB1A002E8CF2 /* BaseViewController.swift in Sources */,

--- a/EatSSU-iOS/EatSSU-iOS/Global/Supports/SceneDelegate.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Global/Supports/SceneDelegate.swift
@@ -28,7 +28,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(windowScene: windowScene)
         window?.windowScene = windowScene
-        let navigationController = UINavigationController(rootViewController: MyPageViewController())
+        let navigationController = UINavigationController(rootViewController: HomeViewController())
         window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
         

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Home/Model/MenuTypeInfo.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Home/Model/MenuTypeInfo.swift
@@ -1,0 +1,13 @@
+//
+//  MenuTypeInfo.swift
+//  EatSSU-iOS
+//
+//  Created by 최지우 on 2023/07/30.
+//
+
+import Foundation
+
+struct MenuTypeInfo {
+    let menuType: String
+    let menuID: Int
+}

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Home/Model/MenuTypeInfo.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Home/Model/MenuTypeInfo.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 struct MenuTypeInfo {
-    let menuType: String
-    let menuID: Int
+    var menuType: String
+    var menuID: Int
 }

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/HomeRestaurantView.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Home/View/HomeRestaurantView.swift
@@ -11,10 +11,20 @@ import Moya
 import SnapKit
 import Then
 
+protocol TableViewCellSelectionDelegate: AnyObject {
+    func didSelectCell()
+}
+
+protocol BindCellMenuTypeInfoDelegate: AnyObject {
+    func didBindMenuTypeInfo(menuTypeInfo: MenuTypeInfo)
+}
+
 class HomeRestaurantView: BaseUIView {
     
     //MARK: - Properties
     
+    var delegate: TableViewCellSelectionDelegate?
+    var delegateMenu: BindCellMenuTypeInfoDelegate?
     let menuProvider = MoyaProvider<HomeRouter>()
     private var currentRestaurant = ""
     lazy var restaurantInfoButton = [dormitoryCoordinateButton, dodamCoordinateButton, studentCoordinateButton, foodCourtCoordinateButton, snackCornerCoordinateButton, theKitchenCoordinateButton]
@@ -278,9 +288,6 @@ extension HomeRestaurantView: UITableViewDataSource {
         return cell
     }
     
-    func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
-        return nil
-    }
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let header = MenuHeaderView()
@@ -288,7 +295,23 @@ extension HomeRestaurantView: UITableViewDataSource {
     }
 }
 
-extension HomeRestaurantView: UITableViewDelegate {}
+extension HomeRestaurantView: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        /// push VC
+        delegate?.didSelectCell()
+        
+        /// bind Data
+        var menuTypeInfo: MenuTypeInfo = MenuTypeInfo(menuType: "", menuID: 0)
+        if tableView.tag < 4 {  // "CHANGE"
+            menuTypeInfo.menuType = "CHANGE"
+            menuTypeInfo.menuID = changedMenuData["DODAM"]?[indexPath.row].mealId ?? 0
+        } else {    // "FIX"
+            menuTypeInfo.menuType = "FIX"
+            menuTypeInfo.menuID = fixedMenuData?.fixMenuInfoList?[indexPath.row].menuId ?? 0
+        }
+        delegateMenu?.didBindMenuTypeInfo(menuTypeInfo: menuTypeInfo)
+    }
+}
 
 extension HomeRestaurantView: UISheetPresentationControllerDelegate {
     func sheetPresentationControllerDidChangeSelectedDetentIdentifier(_ sheetPresentationController: UISheetPresentationController) {

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Home/ViewController/HomeComponent/DinnerViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Home/ViewController/HomeComponent/DinnerViewController.swift
@@ -30,6 +30,7 @@ class DinnerViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        dinnerView.delegate = self
         
         setButtonEvent()
     }
@@ -80,5 +81,12 @@ class DinnerViewController: BaseViewController {
         ppc?.sourceView = self.view
         ppc?.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0)
         present(mapVC, animated: true, completion: nil)
+    }
+}
+
+extension DinnerViewController: TableViewCellSelectionDelegate {
+    func didSelectCell() {
+        let reviewViewController = ReviewViewController()
+        self.navigationController?.pushViewController(reviewViewController, animated: true)
     }
 }

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Home/ViewController/HomeComponent/LunchViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Home/ViewController/HomeComponent/LunchViewController.swift
@@ -30,6 +30,7 @@ class LunchViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        lunchView.delegate = self
         
         setButtonEvent()        
     }
@@ -76,3 +77,11 @@ class LunchViewController: BaseViewController {
     }
 }
 
+extension LunchViewController: TableViewCellSelectionDelegate {
+    func didSelectCell() {
+        let reviewViewController = ReviewViewController()
+        self.navigationController?.pushViewController(reviewViewController, animated: true)
+        lunchView.delegateMenu = reviewViewController
+    }
+    
+}

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Home/ViewController/HomeComponent/MorningViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Home/ViewController/HomeComponent/MorningViewController.swift
@@ -31,6 +31,7 @@ class MorningViewController: BaseViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        morningView.delegate = self
         
         setButtonEvent()
     }
@@ -65,4 +66,13 @@ class MorningViewController: BaseViewController {
         morningView.getChangeMenuTableResponse(date: date, restaurant: "DODAM", time: "MORNING")
         morningView.getChangeMenuTableResponse(date: date, restaurant: "HAKSIK", time: "MORNING")
     }
+}
+
+extension MorningViewController: TableViewCellSelectionDelegate {
+    func didSelectCell() {
+        let reviewViewController = ReviewViewController()
+        self.navigationController?.pushViewController(reviewViewController, animated: true)
+    }
+    
+    
 }

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Review/ViewController/ReviewViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Review/ViewController/ReviewViewController.swift
@@ -184,3 +184,10 @@ extension ReviewViewController {
         }
     }
 }
+
+extension ReviewViewController: BindCellMenuTypeInfoDelegate {
+    func didBindMenuTypeInfo(menuTypeInfo: MenuTypeInfo) {
+        print(menuTypeInfo)
+    }
+    
+}


### PR DESCRIPTION
## 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 메뉴 테이블 cell 클릭 시, API 호출을 위해 필요한 데이터를 전달하는 로직 구현하였습니다.

## 작업 사항

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 필요한 데이터만 전달하기 위한`MenuTypeInfo` 구조체입니다.
```
  struct MenuTypeInfo {
    var menuType: String
    var menuID: Int
}
```
- delegate 데이터 전달 로직 구현하였고, HomeVC -> ReviewVC 푸시될 때, `didBindMenuTypeInfo`함수 실행되어 print문으로 확인하였습니다. `menuTypeInfo`사용하시면 됩니다.
```
 extension ReviewViewController: BindCellMenuTypeInfoDelegate {
    func didBindMenuTypeInfo(menuTypeInfo: MenuTypeInfo) {
        print(menuTypeInfo)
    }
    
}
```

## 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| HomeVC -> ReviewVC 데이터 전달 | |

https://github.com/EAT-SSU/EatSSU-iOS/assets/102797359/11e678c4-137f-41f2-ad03-4a785302aa52



## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #74
