### PR TITLE
[Feat] #90 Apple로그인 API 연동 완료

### DIFF
--- a/EatSSU-iOS/EatSSU-iOS.xcodeproj/project.pbxproj
+++ b/EatSSU-iOS/EatSSU-iOS.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		0588407D2A80E2A90007AA98 /* MyReviewResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0588407C2A80E2A90007AA98 /* MyReviewResponse.swift */; };
 		0588407F2A80E3ED0007AA98 /* MyRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0588407E2A80E3EC0007AA98 /* MyRouter.swift */; };
 		05A4C88429DFE42A004B9A81 /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05A4C88329DFE42A004B9A81 /* UIStackView+.swift */; };
+		05B0AB022A84DE7C00713C09 /* AppleLoginRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B0AB012A84DE7C00713C09 /* AppleLoginRequest.swift */; };
 		05EC82FC2A0BD17F00851B55 /* NoticeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05EC82FB2A0BD17F00851B55 /* NoticeModel.swift */; };
 		7B2BBF96299A1AC400EE0F1F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2BBF95299A1AC400EE0F1F /* AppDelegate.swift */; };
 		7B2BBF98299A1AC400EE0F1F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2BBF97299A1AC400EE0F1F /* SceneDelegate.swift */; };
@@ -159,6 +160,7 @@
 		0588407C2A80E2A90007AA98 /* MyReviewResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyReviewResponse.swift; sourceTree = "<group>"; };
 		0588407E2A80E3EC0007AA98 /* MyRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyRouter.swift; sourceTree = "<group>"; };
 		05A4C88329DFE42A004B9A81 /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
+		05B0AB012A84DE7C00713C09 /* AppleLoginRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleLoginRequest.swift; sourceTree = "<group>"; };
 		05C5EC002A0BCF2300CC6A58 /* NoticeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeViewController.swift; sourceTree = "<group>"; };
 		05EC82FB2A0BD17F00851B55 /* NoticeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeModel.swift; sourceTree = "<group>"; };
 		05EC82FF2A0BD40900851B55 /* NoticeTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeTableViewCell.swift; sourceTree = "<group>"; };
@@ -360,6 +362,7 @@
 				057A0B282A222F7E00F10B85 /* SignInRequest.swift */,
 				051F7E622A70E4F700CE9F87 /* KakaoLoginRequest.swift */,
 				7B9998B92A7944FD0043C592 /* UserNicknameRequest.swift */,
+				05B0AB012A84DE7C00713C09 /* AppleLoginRequest.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -956,6 +959,7 @@
 				057A0B272A222D4A00F10B85 /* AuthRouter.swift in Sources */,
 				057A0B192A22254500F10B85 /* SignUpRequest.swift in Sources */,
 				0588407F2A80E3ED0007AA98 /* MyRouter.swift in Sources */,
+				05B0AB022A84DE7C00713C09 /* AppleLoginRequest.swift in Sources */,
 				7BBD4CC32A70FA4A00515F67 /* ChangeNicknameViewController.swift in Sources */,
 				7BBD4CAE2A6E5CE600515F67 /* RestaurantInfoTimeTableView.swift in Sources */,
 				7B9899AA2A0B98E700D1A076 /* oRestaurantInfoViewController.swift in Sources */,
@@ -1119,7 +1123,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 3DGF5D388H;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "EatSSU-iOS/Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
@@ -1152,7 +1156,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 3DGF5D388H;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "EatSSU-iOS/Info.plist";
 				INFOPLIST_KEY_LSApplicationCategoryType = "";

--- a/EatSSU-iOS/EatSSU-iOS/Network/DTO/Auth/AppleLoginRequest.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Network/DTO/Auth/AppleLoginRequest.swift
@@ -1,0 +1,16 @@
+//
+//  AppleLoginRequest.swift
+//  EatSSU-iOS
+//
+//  Created by 박윤빈 on 2023/08/10.
+//
+
+import Foundation
+
+struct AppleLoginRequest: Codable {
+    let identityToken: String
+    
+    init(identityToken: String) {
+        self.identityToken = identityToken
+    }
+}

--- a/EatSSU-iOS/EatSSU-iOS/Network/DTO/Auth/AuthRouter.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Network/DTO/Auth/AuthRouter.swift
@@ -12,6 +12,7 @@ enum AuthRouter {
     case signUp(param: SignUpRequest)
     case signIn(param: SignInRequest)
     case kakaoLogin(param: KakaoLoginRequest)
+    case appleLogin(param: AppleLoginRequest)
 }
 
 extension AuthRouter: TargetType {
@@ -27,6 +28,8 @@ extension AuthRouter: TargetType {
         return "/user/login"
     case .kakaoLogin:
         return "/oauth/kakao"
+    case .appleLogin:
+        return "/oauth/apple"
     }
   }
   
@@ -37,6 +40,8 @@ extension AuthRouter: TargetType {
     case .signIn:
         return .post
     case .kakaoLogin:
+        return .post
+    case .appleLogin:
         return .post
     }
   }
@@ -49,6 +54,8 @@ extension AuthRouter: TargetType {
         return .requestJSONEncodable(param)
     case .kakaoLogin(param: let param):
         return .requestJSONEncodable(param)
+    case .appleLogin(param: let param):
+        return .requestJSONEncodable(param)
     }
   }
 
@@ -59,4 +66,3 @@ extension AuthRouter: TargetType {
     }
   }
 }
-

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Auth/ViewController/NewLoginViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Auth/ViewController/NewLoginViewController.swift
@@ -151,6 +151,29 @@ extension NewLoginViewController {
             }
         }
     }
+    
+    func postAppleLoginRequest(token: String) {
+        self.authProvider.request(.appleLogin(param: AppleLoginRequest(identityToken: token))) { response in
+            switch response {
+            case .success(let moyaResponse):
+                do {
+                    print(moyaResponse.statusCode)
+                    let responseData = try moyaResponse.map(SignResponse.self)
+                    self.addTokenInRealm(accessToken: responseData.accessToken,
+                                         refreshToken: responseData.refreshToken)
+                    
+                    let setNicknameViewController = SetNickNameViewController()
+                    self.navigationController?.pushViewController(setNicknameViewController, animated: true)
+                } catch(let err) {
+                    self.presentBottomAlert(err.localizedDescription)
+                    print(err.localizedDescription)
+                }
+            case .failure(let err):
+                self.presentBottomAlert(err.localizedDescription)
+                print(err.localizedDescription)
+            }
+        }
+    }
 }
 
 extension NewLoginViewController: ASAuthorizationControllerPresentationContextProviding, ASAuthorizationControllerDelegate {
@@ -170,7 +193,8 @@ extension NewLoginViewController: ASAuthorizationControllerPresentationContextPr
             let email = appleIDCredential.email
             let idToken = appleIDCredential.identityToken!
             let tokeStr = String(data: idToken, encoding: .utf8)
-            // FIXME: - 여기에 애플로그인 기능 추가
+    
+            postAppleLoginRequest(token: tokeStr ?? "")
             print("User ID : \(userIdentifier)")
             print("User Email : \(email ?? "")")
             print("User Name : \((fullName?.givenName ?? "") + (fullName?.familyName ?? ""))")


### PR DESCRIPTION
## 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 애플로그인 identity token 서버로 전달 완료했습니다.

## 작업 사항

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 서버에서 수정할 부분이 조금 있다고 하는데, 수정한다고 해서 클라쪽 로직은 바뀌지 않을 것 같아 그냥 PR 올립니다!

## 스크린샷



|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 애플로그인 | <img src="https://github.com/EAT-SSU/EatSSU-iOS/assets/109334968/f221a5c0-e296-44c9-8d55-2a2472f3d917" width="400"> |

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #90 
