### PR TITLE
[FEAT] #102 fix 메뉴 셀 선택 시, 데이터 전달 구현

### DIFF
--- a/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/View/RestaurantTableView/RestaurantTableViewMenuCell.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/View/RestaurantTableView/RestaurantTableViewMenuCell.swift
@@ -79,9 +79,6 @@ class RestaurantTableViewMenuCell: BaseTableViewCell {
     func bind(_ model: MenuTypeInfo) {
         switch model {
         case .change(let data):
-            print(String(data.price))
-            print(String(data.mainGrade ?? 0))
-            print(data.changeMenuInfoList.map { $0.name }.joined(separator: "+"))
             priceLabel.text = String(data.price)
             ratingLabel.text = String(data.mainGrade ?? 0)
             nameLabel.text = data.changeMenuInfoList.map { $0.name }.joined(separator: "+")

--- a/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeRestaurantViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeRestaurantViewController.swift
@@ -213,7 +213,10 @@ extension HomeRestaurantViewController: UITableViewDelegate {
         
         if [0, 1, 2].contains(indexPath.section) {
             reviewMenuTypeInfo.menuType = "CHANGE"
-            reviewMenuTypeInfo.menuID = changeMenuTableViewData[restaurant]?[indexPath.row - restaurantTableViewMenuTitleCellCount].mealId ?? 0
+            reviewMenuTypeInfo.menuID = changeMenuTableViewData[restaurant]?[indexPath.row - restaurantTableViewMenuTitleCellCount].mealId ?? 100
+        } else if [3, 4, 5].contains(indexPath.section) {
+            reviewMenuTypeInfo.menuType = "FIX"
+            reviewMenuTypeInfo.menuID = fixMenuTableViewData[restaurant]?.fixMenuInfoList[indexPath.row - restaurantTableViewMenuTitleCellCount].menuId ?? 100
         }
         
         /// push VC

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Review/ViewController/ReviewViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Review/ViewController/ReviewViewController.swift
@@ -245,6 +245,8 @@ extension ReviewViewController {
 extension ReviewViewController: ReviewMenuTypeInfoDelegate {
     func didDelegateReviewMenuTypeInfo(for menuTypeData: ReviewMenuTypeInfo) {
         var reviewMenuTypeInfo = ReviewMenuTypeInfo(menuType: menuTypeData.menuType, menuID: menuTypeData.menuID)
+        type = reviewMenuTypeInfo.menuType
+        menuID = reviewMenuTypeInfo.menuID
         print("👍reviewMenuTypeInfo: \(reviewMenuTypeInfo)")
     }
 }

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Review/ViewController/ReviewViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Review/ViewController/ReviewViewController.swift
@@ -245,6 +245,7 @@ extension ReviewViewController {
 extension ReviewViewController: ReviewMenuTypeInfoDelegate {
     func didDelegateReviewMenuTypeInfo(for menuTypeData: ReviewMenuTypeInfo) {
         var reviewMenuTypeInfo = ReviewMenuTypeInfo(menuType: menuTypeData.menuType, menuID: menuTypeData.menuID)
-        print("reviewMenuTypeInfo: \(reviewMenuTypeInfo)")
+        print("👍reviewMenuTypeInfo: \(reviewMenuTypeInfo)")
     }
 }
+


### PR DESCRIPTION
## 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- fix 메뉴 셀 선택 시, `reviewVC`로 데이터 전달 구현하였습니다.

## 작업 사항

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 로그 아래처럼 찍히니 확인해주세요.
`print("👍reviewMenuTypeInfo: \(reviewMenuTypeInfo)")`
<img width="558" alt="스크린샷 2023-08-16 오전 2 47 19" src="https://github.com/EAT-SSU/EatSSU-iOS/assets/102797359/739b5b81-9e72-4f60-ae4c-7caa3c0b1c75">

<img width="548" alt="스크린샷 2023-08-16 오전 2 47 44" src="https://github.com/EAT-SSU/EatSSU-iOS/assets/102797359/d546292a-a5af-4521-a75c-aa2ba94da21e">



## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #102 
