### PR TITLE
[Feat] #104 change 메뉴 cell 클릭 시, 전달 data 요소 추가

### DIFF
--- a/EatSSU-iOS/EatSSU-iOS.xcodeproj/project.pbxproj
+++ b/EatSSU-iOS/EatSSU-iOS.xcodeproj/project.pbxproj
@@ -558,7 +558,6 @@
 			children = (
 				7B51C5A22A63268A0016B418 /* RestaurantInfoModel.swift */,
 				7BBD4CA92A6D3B7A00515F67 /* TimeData.swift */,
-				7BBD4CF42A765A3000515F67 /* ReviewMenuTypeInfo.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -733,6 +732,7 @@
 			children = (
 				7B51C5A62A63C7230016B418 /* ChangeMenuInfoModel.swift */,
 				7B51C5BC2A654FB40016B418 /* FixedMenuInfoModel.swift */,
+				7BBD4CF42A765A3000515F67 /* ReviewMenuTypeInfo.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";

--- a/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/Model/ReviewMenuTypeInfo.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/Model/ReviewMenuTypeInfo.swift
@@ -10,4 +10,5 @@ import Foundation
 struct ReviewMenuTypeInfo {
     var menuType: String
     var menuID: Int
+    var changeMenuIDList: [Int]?
 }

--- a/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeRestaurantViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeRestaurantViewController.swift
@@ -214,11 +214,6 @@ extension HomeRestaurantViewController: UITableViewDelegate {
         if [0, 1, 2].contains(indexPath.section) {
             reviewMenuTypeInfo.menuType = "CHANGE"
             reviewMenuTypeInfo.menuID = changeMenuTableViewData[restaurant]?[indexPath.row - restaurantTableViewMenuTitleCellCount].mealId ?? 0
-//            reviewMenuTypeInfo.changeMenuIDList
-//            if let changeMenuInfoList = data.first?["changeMenuInfoList"] as? [[String: Any]] {
-//                let menuIds = changeMenuInfoList.compactMap { $0["menuId"] as? Int }
-//                print(menuIds)  // 출력: [114, 89, 90]
-//            }
             if let list = changeMenuTableViewData[restaurant]?[indexPath.row - restaurantTableViewMenuTitleCellCount].changeMenuInfoList {
                 reviewMenuTypeInfo.changeMenuIDList = list.compactMap { $0.menuId }
             }

--- a/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeRestaurantViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeRestaurantViewController.swift
@@ -214,6 +214,17 @@ extension HomeRestaurantViewController: UITableViewDelegate {
         if [0, 1, 2].contains(indexPath.section) {
             reviewMenuTypeInfo.menuType = "CHANGE"
             reviewMenuTypeInfo.menuID = changeMenuTableViewData[restaurant]?[indexPath.row - restaurantTableViewMenuTitleCellCount].mealId ?? 0
+//            reviewMenuTypeInfo.changeMenuIDList
+//            if let changeMenuInfoList = data.first?["changeMenuInfoList"] as? [[String: Any]] {
+//                let menuIds = changeMenuInfoList.compactMap { $0["menuId"] as? Int }
+//                print(menuIds)  // 출력: [114, 89, 90]
+//            }
+            if let list = changeMenuTableViewData[restaurant]?[indexPath.row - restaurantTableViewMenuTitleCellCount].changeMenuInfoList {
+                reviewMenuTypeInfo.changeMenuIDList = list.compactMap { $0.menuId }
+            }
+        } else if [3, 4, 5].contains(indexPath.section) {
+            reviewMenuTypeInfo.menuType = "FIX"
+            reviewMenuTypeInfo.menuID = fixMenuTableViewData[restaurant]?.fixMenuInfoList[indexPath.row - restaurantTableViewMenuTitleCellCount].menuId ?? 100
         }
         
         /// push VC

--- a/EatSSU-iOS/EatSSU-iOS/Screen/Review/ViewController/ReviewViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/Review/ViewController/ReviewViewController.swift
@@ -244,7 +244,7 @@ extension ReviewViewController {
 
 extension ReviewViewController: ReviewMenuTypeInfoDelegate {
     func didDelegateReviewMenuTypeInfo(for menuTypeData: ReviewMenuTypeInfo) {
-        var reviewMenuTypeInfo = ReviewMenuTypeInfo(menuType: menuTypeData.menuType, menuID: menuTypeData.menuID)
-        print("reviewMenuTypeInfo: \(reviewMenuTypeInfo)")
+        var reviewMenuTypeInfo = ReviewMenuTypeInfo(menuType: menuTypeData.menuType, menuID: menuTypeData.menuID, changeMenuIDList: menuTypeData.changeMenuIDList)
+        print("👍reviewMenuTypeInfo: \(reviewMenuTypeInfo)")
     }
 }


### PR DESCRIPTION
## 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- change 메뉴 cell 클릭 시, menuIdList 데이터 추가하여 전달합니다.

## 작업 사항

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 요렇게 전달됩니다!
<img width="680" alt="스크린샷 2023-08-16 오전 5 02 18" src="https://github.com/EAT-SSU/EatSSU-iOS/assets/102797359/a78b37e0-17ab-4266-9100-466be1955297">


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #104 
