### PR TITLE
[Feat] #99 date 변경 시, 메뉴 api 바인딩하여 테이블 reload

### DIFF
--- a/EatSSU-iOS/EatSSU-iOS.xcodeproj/project.pbxproj
+++ b/EatSSU-iOS/EatSSU-iOS.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		7B9998FC2A839BF90043C592 /* RestaurantTableViewMenuTitleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9998FB2A839BF90043C592 /* RestaurantTableViewMenuTitleCell.swift */; };
 		7B9999092A8627540043C592 /* MenuTypeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9999082A8627540043C592 /* MenuTypeInfo.swift */; };
 		7B99990C2A86313E0043C592 /* MenuType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B99990B2A86313E0043C592 /* MenuType.swift */; };
+		7B9999252A8C03320043C592 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9999242A8C03320043C592 /* String.swift */; };
 		7BBD4C972A67DAEF00515F67 /* ChangeMenuTableResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD4C962A67DAEF00515F67 /* ChangeMenuTableResponse.swift */; };
 		7BBD4CA22A6C406C00515F67 /* RestaurantInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD4CA12A6C406C00515F67 /* RestaurantInfoView.swift */; };
 		7BBD4CA62A6D275B00515F67 /* RestaurantInfoRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD4CA52A6D275B00515F67 /* RestaurantInfoRouter.swift */; };
@@ -217,6 +218,7 @@
 		7B9998FB2A839BF90043C592 /* RestaurantTableViewMenuTitleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestaurantTableViewMenuTitleCell.swift; sourceTree = "<group>"; };
 		7B9999082A8627540043C592 /* MenuTypeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuTypeInfo.swift; sourceTree = "<group>"; };
 		7B99990B2A86313E0043C592 /* MenuType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuType.swift; sourceTree = "<group>"; };
+		7B9999242A8C03320043C592 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		7BBD4C962A67DAEF00515F67 /* ChangeMenuTableResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeMenuTableResponse.swift; sourceTree = "<group>"; };
 		7BBD4CA12A6C406C00515F67 /* RestaurantInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestaurantInfoView.swift; sourceTree = "<group>"; };
 		7BBD4CA52A6D275B00515F67 /* RestaurantInfoRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestaurantInfoRouter.swift; sourceTree = "<group>"; };
@@ -491,6 +493,7 @@
 				058326652A4D97BC004A295F /* UICollectionViewCell+.swift */,
 				7B51C5942A62A0B10016B418 /* CALayer.swift */,
 				051F7E6A2A78FD3700CE9F87 /* UIImageView+.swift */,
+				7B9999242A8C03320043C592 /* String.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -912,6 +915,7 @@
 				058326612A4D9422004A295F /* ChoiceMenuViewController.swift in Sources */,
 				7BD73CE629D2F9C60076DC77 /* LoginViewController.swift in Sources */,
 				0588407D2A80E2A90007AA98 /* MyReviewResponse.swift in Sources */,
+				7B9999252A8C03320043C592 /* String.swift in Sources */,
 				7B63C45B29C100DE0070C588 /* DinnerViewController.swift in Sources */,
 				7B51C5A72A63C7230016B418 /* ChangeMenuInfoModel.swift in Sources */,
 				057A0B312A273DDF00F10B85 /* MoyaPluggin.swift in Sources */,

--- a/EatSSU-iOS/EatSSU-iOS/Global/Extension/String.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Global/Extension/String.swift
@@ -1,0 +1,18 @@
+//
+//  String.swift
+//  EatSSU-iOS
+//
+//  Created by 최지우 on 2023/08/16.
+//
+
+import Foundation
+
+extension String {
+    func stringFromDate() -> String {
+        let now = Date()
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = self
+        dateFormatter.locale = Locale(identifier: "ko_KR")
+        return dateFormatter.string(from: now)
+    }
+}

--- a/EatSSU-iOS/EatSSU-iOS/Global/Literal/TextLiteral.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Global/Literal/TextLiteral.swift
@@ -36,6 +36,7 @@ enum TextLiteral {
     static let foodCourtRawValue: String = "FOOD_COURT"
     static let snackCornerRawValue: String = "SNACK_CORNER"
     static let theKitchenRawValue: String = "THE_KITCHEN"
+    static let lunchRawValue: String = "LUNCH"
 
     // MARK: - Mypage
     

--- a/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/View/HomeCalendarView.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/View/HomeCalendarView.swift
@@ -91,9 +91,7 @@ extension HomeCalendarView: FSCalendarDataSource, FSCalendarDelegate {
         
         // 오늘 날짜 Select
         calendar.select(Date())
-        
-        // 캘린더 숫자와 subtitle간의 간격 조정
-//        calendar.appearance.subtitleOffset = CGPoint(x: 0, y: 10)
+
     }
     
         // 날짜를 선택했을 때 할일을 지정

--- a/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeRestaurantViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeRestaurantViewController.swift
@@ -118,8 +118,10 @@ class HomeRestaurantViewController: BaseViewController {
         getFixMenuData(restaurant: "FOOD_COURT") {}
         getFixMenuData(restaurant: "SNACK_CORNER") {}
         getFixMenuData(restaurant: "THE_KITCHEN") {}
+        print("✅ fetchData 끝")
         
-//        restaurantView.restaurantTableView.reloadData()
+        /// 스크롤 최상단 이동
+        restaurantView.restaurantTableView.setContentOffset(CGPoint(x: 0.0, y: 0.0), animated: true)
     }
 }
 

--- a/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeRestaurantViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeRestaurantViewController.swift
@@ -112,12 +112,16 @@ class HomeRestaurantViewController: BaseViewController {
 
     func fetchData(date: String, time: String) {
         print("🎒 \(time)")
-        getChageMenuData(date: date, restaurant: "DOMITORY", time: time) {}
-        getChageMenuData(date: date, restaurant: "DODAM", time: time) {}
-        getChageMenuData(date: date, restaurant: "HAKSIK", time: time) {}
-        getFixMenuData(restaurant: "FOOD_COURT") {}
-        getFixMenuData(restaurant: "SNACK_CORNER") {}
-        getFixMenuData(restaurant: "THE_KITCHEN") {}
+        getChageMenuData(date: date, restaurant: TextLiteral.dormitoryRawValue, time: time) {}
+        getChageMenuData(date: date, restaurant: TextLiteral.dodamRawValue, time: time) {}
+        getChageMenuData(date: date, restaurant: TextLiteral.studentRestaurantRawValue, time: time) {}
+        
+        if time == TextLiteral.lunchRawValue {
+            getFixMenuData(restaurant: "FOOD_COURT") {}
+            getFixMenuData(restaurant: "SNACK_CORNER") {}
+            getFixMenuData(restaurant: "THE_KITCHEN") {}
+        }
+        
         print("✅ fetchData 끝")
         
         /// 스크롤 최상단 이동

--- a/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeRestaurantViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeRestaurantViewController.swift
@@ -61,8 +61,6 @@ class HomeRestaurantViewController: BaseViewController {
         
         setDelegate()
         setTableView()
-        
-        fetchData()
 
     }
     
@@ -112,13 +110,16 @@ class HomeRestaurantViewController: BaseViewController {
         return restaurantRawValue[section]
     }
 
-    func fetchData() {
-        getChageMenuData(date: "20230714", restaurant: "DOMITORY", time: "LUNCH") {}
-        getChageMenuData(date: "20230714", restaurant: "DODAM", time: "LUNCH") {}
-        getChageMenuData(date: "20230714", restaurant: "HAKSIK", time: "LUNCH") {}
+    func fetchData(date: String, time: String) {
+        print("🎒 \(time)")
+        getChageMenuData(date: date, restaurant: "DOMITORY", time: time) {}
+        getChageMenuData(date: date, restaurant: "DODAM", time: time) {}
+        getChageMenuData(date: date, restaurant: "HAKSIK", time: time) {}
         getFixMenuData(restaurant: "FOOD_COURT") {}
         getFixMenuData(restaurant: "SNACK_CORNER") {}
         getFixMenuData(restaurant: "THE_KITCHEN") {}
+        
+//        restaurantView.restaurantTableView.reloadData()
     }
 }
 

--- a/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeTimeTabmanController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeTimeTabmanController.swift
@@ -11,7 +11,7 @@ import SnapKit
 import Tabman
 import Pageboy
 
-class HomeTabmanController: TabmanViewController {
+class HomeTimeTabmanController: TabmanViewController {
     
     // MARK: - Properties
     
@@ -21,7 +21,9 @@ class HomeTabmanController: TabmanViewController {
     lazy var morningViewController = HomeRestaurantViewController()
     lazy var lunchViewController = HomeRestaurantViewController()
     lazy var dinnerViewController = HomeRestaurantViewController()
-    private lazy var viewControllers = [morningViewController, lunchViewController, dinnerViewController]
+    private lazy var viewControllers = [morningViewController,
+                                        lunchViewController,
+                                        dinnerViewController]
     
     //MARK: - Life Cycles
     
@@ -29,6 +31,7 @@ class HomeTabmanController: TabmanViewController {
         super.viewDidLoad()
 
         registerTabBar()
+        dateFetchData(for: "yyyyMMdd".stringFromDate())
     }
  
     //MARK: - Functions
@@ -39,11 +42,23 @@ class HomeTabmanController: TabmanViewController {
         setLayoutTabBar(ctBar: bar)
         addBar(bar, dataSource: self, at: .top)
     }
+    
+    func dateFetchData(for date: String) {
+        morningViewController.fetchData(date: date, time: "MORNING")
+        lunchViewController.fetchData(date: date, time: "LUNCH")
+        dinnerViewController.fetchData(date: date, time: "DINNER")
+    }
+    
+    func changeDateFormat(date: Date) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyyMMdd"
+        return dateFormatter.string(from: date)
+    }
 }
 
 // MARK: - PageBoy Extension
 
-extension HomeTabmanController: PageboyViewControllerDataSource, TMBarDataSource {
+extension HomeTimeTabmanController: PageboyViewControllerDataSource, TMBarDataSource {
     
     func numberOfViewControllers(in pageboyViewController: Pageboy.PageboyViewController) -> Int {
         return viewControllers.count
@@ -88,6 +103,13 @@ extension HomeTabmanController: PageboyViewControllerDataSource, TMBarDataSource
         ctBar.indicator.overscrollBehavior = .compress
         ctBar.layout.contentMode = .fit
         ctBar.layout.transitionStyle = .snap
+    }
+}
+
+extension HomeTimeTabmanController: CalendarSeletionDelegate {
+    func didSelectCalendar(date: Date) {
+        print("🐯\(date)")
+        dateFetchData(for: changeDateFormat(date: date))
     }
 }
 

--- a/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeTimeTabmanController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeTimeTabmanController.swift
@@ -45,11 +45,9 @@ class HomeTimeTabmanController: TabmanViewController {
     
     func dateFetchData(for date: String) {
         morningViewController.fetchData(date: date, time: "MORNING")
-        morningViewController.restaurantView.restaurantTableView.reloadData()
         lunchViewController.fetchData(date: date, time: "LUNCH")
-        lunchViewController.restaurantView.restaurantTableView.reloadData()
         dinnerViewController.fetchData(date: date, time: "DINNER")
-        dinnerViewController.restaurantView.restaurantTableView.reloadData()
+    
     }
     
     func changeDateFormat(date: Date) -> String {
@@ -113,6 +111,11 @@ extension HomeTimeTabmanController: CalendarSeletionDelegate {
     func didSelectCalendar(date: Date) {
         print("🐯\(date)")
         dateFetchData(for: changeDateFormat(date: date))
+        
+        morningViewController.restaurantView.restaurantTableView.reloadData()
+        lunchViewController.restaurantView.restaurantTableView.reloadData()
+        dinnerViewController.restaurantView.restaurantTableView.reloadData()
+        print("✅ reload 끝 ")
     }
 }
 

--- a/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeTimeTabmanController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeTimeTabmanController.swift
@@ -45,8 +45,11 @@ class HomeTimeTabmanController: TabmanViewController {
     
     func dateFetchData(for date: String) {
         morningViewController.fetchData(date: date, time: "MORNING")
+        morningViewController.restaurantView.restaurantTableView.reloadData()
         lunchViewController.fetchData(date: date, time: "LUNCH")
+        lunchViewController.restaurantView.restaurantTableView.reloadData()
         dinnerViewController.fetchData(date: date, time: "DINNER")
+        dinnerViewController.restaurantView.restaurantTableView.reloadData()
     }
     
     func changeDateFormat(date: Date) -> String {

--- a/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeViewController.swift
@@ -29,7 +29,7 @@ class HomeViewController: BaseViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
-        homeCalendarView.delegate = self
+        homeCalendarView.delegate = tabmanController
         
         registerTabman()
         setnavigation()

--- a/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeViewController.swift
+++ b/EatSSU-iOS/EatSSU-iOS/Screen/NewHome/ViewController/HomeViewController.swift
@@ -21,7 +21,7 @@ class HomeViewController: BaseViewController {
     
     // MARK: - UI Components
     
-    let tabmanController = HomeTabmanController()
+    let tabmanController = HomeTimeTabmanController()
     let homeCalendarView = HomeCalendarView()
         
     //MARK: - Life Cycles


### PR DESCRIPTION
## 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 사용자가 날짜 변경 시, HomeRestaurantViewController 로의 날짜를 delegate로써 전달합니다.
- 전달 받은 날짜에 따른 메뉴 api를 바인딩하여 식당 테이블 reload를 진행합니다.

## 작업 사항

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 고정메뉴는 점심만 받아오도록 수정하였습니다.
- 날짜 변경 시, 스크롤이 최상단으로 가도록 설정하였습니다.
- 오늘 날짜의 아침/점심/저녁 메뉴를 클릭하지 않고, 날짜 변경시 에러가 납니다. 로드가 안 된 상태에서 날짜를 변경하면서 에러가 나는 것 같네요. 다음 이슈에서 바로 해결할께요! 

## 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 홈 뷰 | ![ezgif com-video-to-gif (13)](https://github.com/EAT-SSU/EatSSU-iOS/assets/102797359/785ff320-5512-476c-82c5-ea562a860037) |


## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #99
