### PR TITLE
[#14] 사용자 인증 소스코드를 MVVM의 View 계층에 부합한 부분으로 설계

### DIFF
--- a/EatSSU-iOS/EatSSU-iOS.xcodeproj/project.pbxproj
+++ b/EatSSU-iOS/EatSSU-iOS.xcodeproj/project.pbxproj
@@ -157,8 +157,11 @@
 		7BF5CC3C2A53DD0600E4EE11 /* PostUIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5CC3B2A53DD0600E4EE11 /* PostUIButton.swift */; };
 		7BFD09BF2A21E6E400B40054 /* FixedMenuTableResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFD09BE2A21E6E400B40054 /* FixedMenuTableResponse.swift */; };
 		7BFD09C12A21EE3E00B40054 /* HomeRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFD09C02A21EE3E00B40054 /* HomeRouter.swift */; };
-		DA13BC9F2C26A7BF0083244A /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA13BC9E2C26A7BF0083244A /* View.swift */; };
 		DA5F4B702C192CA8009469C4 /* BaseUINavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5F4B6F2C192CA8009469C4 /* BaseUINavigationBar.swift */; };
+		DA8138172C26CC3B000612EC /* MigratedLoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8138162C26CC3B000612EC /* MigratedLoginView.swift */; };
+		DA8138192C26CC4D000612EC /* MigratedLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8138182C26CC4D000612EC /* MigratedLoginViewController.swift */; };
+		DA81381B2C26CC78000612EC /* MigratedSetNickNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA81381A2C26CC78000612EC /* MigratedSetNickNameView.swift */; };
+		DA81381D2C26CC87000612EC /* MigratedSetNickNameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA81381C2C26CC87000612EC /* MigratedSetNickNameViewController.swift */; };
 		DA83B3E82C18587200F41DB8 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = DA83B3E72C18587200F41DB8 /* RealmSwift */; };
 		DAACFF042C244BDC00763006 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = DAACFF032C244BDC00763006 /* RxCocoa */; };
 		DAACFF062C244BDC00763006 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = DAACFF052C244BDC00763006 /* RxSwift */; };
@@ -305,8 +308,11 @@
 		7BF5CC3B2A53DD0600E4EE11 /* PostUIButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostUIButton.swift; sourceTree = "<group>"; };
 		7BFD09BE2A21E6E400B40054 /* FixedMenuTableResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedMenuTableResponse.swift; sourceTree = "<group>"; };
 		7BFD09C02A21EE3E00B40054 /* HomeRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRouter.swift; sourceTree = "<group>"; };
-		DA13BC9E2C26A7BF0083244A /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
 		DA5F4B6F2C192CA8009469C4 /* BaseUINavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseUINavigationBar.swift; sourceTree = "<group>"; };
+		DA8138162C26CC3B000612EC /* MigratedLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigratedLoginView.swift; sourceTree = "<group>"; };
+		DA8138182C26CC4D000612EC /* MigratedLoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigratedLoginViewController.swift; sourceTree = "<group>"; };
+		DA81381A2C26CC78000612EC /* MigratedSetNickNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigratedSetNickNameView.swift; sourceTree = "<group>"; };
+		DA81381C2C26CC87000612EC /* MigratedSetNickNameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigratedSetNickNameViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -750,7 +756,9 @@
 		7B7E7C682C257708004AFA89 /* Auth */ = {
 			isa = PBXGroup;
 			children = (
-				DA13BC9E2C26A7BF0083244A /* View.swift */,
+				DA8138122C26CBC9000612EC /* View */,
+				DA8138132C26CBD5000612EC /* ViewModel */,
+				DA81380F2C26CB9B000612EC /* SubViews */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -1023,6 +1031,47 @@
 			path = Configurations;
 			sourceTree = "<group>";
 		};
+		DA81380F2C26CB9B000612EC /* SubViews */ = {
+			isa = PBXGroup;
+			children = (
+				DA8138112C26CBC4000612EC /* View */,
+				DA8138102C26CBBE000612EC /* ViewModel */,
+			);
+			path = SubViews;
+			sourceTree = "<group>";
+		};
+		DA8138102C26CBBE000612EC /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		DA8138112C26CBC4000612EC /* View */ = {
+			isa = PBXGroup;
+			children = (
+				DA81381A2C26CC78000612EC /* MigratedSetNickNameView.swift */,
+				DA81381C2C26CC87000612EC /* MigratedSetNickNameViewController.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		DA8138122C26CBC9000612EC /* View */ = {
+			isa = PBXGroup;
+			children = (
+				DA8138162C26CC3B000612EC /* MigratedLoginView.swift */,
+				DA8138182C26CC4D000612EC /* MigratedLoginViewController.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		DA8138132C26CBD5000612EC /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -1175,7 +1224,6 @@
 				7B9999252A8C03320043C592 /* String.swift in Sources */,
 				057A0B312A273DDF00F10B85 /* MoyaPluggin.swift in Sources */,
 				057A0B252A22284400F10B85 /* SignResponse.swift in Sources */,
-				DA13BC9F2C26A7BF0083244A /* View.swift in Sources */,
 				7B51C5A12A6322D60016B418 /* DataTypeProtocol.swift in Sources */,
 				057A0AC72A1B488B00F10B85 /* TotalReviewResponse.swift in Sources */,
 				057A0B212A22278800F10B85 /* RealmService.swift in Sources */,
@@ -1204,6 +1252,7 @@
 				7BBD4CF52A765A3000515F67 /* ReviewMenuTypeInfo.swift in Sources */,
 				7B732BEA2B08FB3000474A35 /* Weekday.swift in Sources */,
 				058326662A4D97BC004A295F /* UICollectionViewCell+.swift in Sources */,
+				DA8138192C26CC4D000612EC /* MigratedLoginViewController.swift in Sources */,
 				7B2BBFB2299A29AF00EE0F1F /* UIColor+.swift in Sources */,
 				052555BA2C0DFD3D00D38E34 /* UILabel+.swift in Sources */,
 				7B6E35542B981E95004F00EE /* FirebaseRemoteConfig.swift in Sources */,
@@ -1243,6 +1292,7 @@
 				056956FD29CB7958002E8CF2 /* ReviewTableCell.swift in Sources */,
 				7B203D3B2B0A1AE700059512 /* ProvisionView.swift in Sources */,
 				056956FF29CB81E2002E8CF2 /* SetRateViewController.swift in Sources */,
+				DA8138172C26CC3B000612EC /* MigratedLoginView.swift in Sources */,
 				7B9998EB2A8279FC0043C592 /* HomeTimeTabmanController.swift in Sources */,
 				7BBD4CB02A6E722A00515F67 /* RestaurantLocation.swift in Sources */,
 				0583266A2A4DC891004A295F /* RateNumberView.swift in Sources */,
@@ -1252,6 +1302,7 @@
 				051F7E692A78F48000CE9F87 /* ReviewListResponse.swift in Sources */,
 				051F7E632A70E4F700CE9F87 /* KakaoLoginRequest.swift in Sources */,
 				057C5B332A837BD5007EDE06 /* BaseButton.swift in Sources */,
+				DA81381B2C26CC78000612EC /* MigratedSetNickNameView.swift in Sources */,
 				7BBD4CC12A6FFE0400515F67 /* MyPageServiceCell.swift in Sources */,
 				7BE4E3CF2B00FAAD0009763A /* ReissueRouter.swift in Sources */,
 				0553A8F32BA74F6700159B5D /* FixedReviewRateResponse.swift in Sources */,
@@ -1276,6 +1327,7 @@
 				057A0B2D2A250C1E00F10B85 /* WriteReviewRouter.swift in Sources */,
 				7B906AF42A1B849D00E4B6A9 /* MyPageViewController.swift in Sources */,
 				7B2BBF98299A1AC400EE0F1F /* SceneDelegate.swift in Sources */,
+				DA81381D2C26CC87000612EC /* MigratedSetNickNameViewController.swift in Sources */,
 				0559705B2A16646B00868C42 /* MenuReviewResponse.swift in Sources */,
 				7B732BE82B08E76000474A35 /* NetworkMonitor.swift in Sources */,
 				7BBD4CA82A6D2A6600515F67 /* RestaurantInfoResponse.swift in Sources */,

--- a/EatSSU-iOS/EatSSU-iOS.xcodeproj/project.pbxproj
+++ b/EatSSU-iOS/EatSSU-iOS.xcodeproj/project.pbxproj
@@ -104,7 +104,6 @@
 		7B7E7C722C2577F0004AFA89 /* C.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7E7C712C2577F0004AFA89 /* C.swift */; };
 		7B7E7C742C2577F3004AFA89 /* D.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7E7C732C2577F3004AFA89 /* D.swift */; };
 		7B7E7C762C257802004AFA89 /* E.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7E7C752C257802004AFA89 /* E.swift */; };
-		7B7E7C782C25780D004AFA89 /* I.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7E7C772C25780D004AFA89 /* I.swift */; };
 		7B7E7C7A2C257810004AFA89 /* H.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7E7C792C257810004AFA89 /* H.swift */; };
 		7B7E7C7C2C257813004AFA89 /* G.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7E7C7B2C257813004AFA89 /* G.swift */; };
 		7B7E7C7E2C257816004AFA89 /* F.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7E7C7D2C257816004AFA89 /* F.swift */; };
@@ -158,6 +157,7 @@
 		7BF5CC3C2A53DD0600E4EE11 /* PostUIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF5CC3B2A53DD0600E4EE11 /* PostUIButton.swift */; };
 		7BFD09BF2A21E6E400B40054 /* FixedMenuTableResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFD09BE2A21E6E400B40054 /* FixedMenuTableResponse.swift */; };
 		7BFD09C12A21EE3E00B40054 /* HomeRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFD09C02A21EE3E00B40054 /* HomeRouter.swift */; };
+		DA13BC9F2C26A7BF0083244A /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA13BC9E2C26A7BF0083244A /* View.swift */; };
 		DA5F4B702C192CA8009469C4 /* BaseUINavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5F4B6F2C192CA8009469C4 /* BaseUINavigationBar.swift */; };
 		DA83B3E82C18587200F41DB8 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = DA83B3E72C18587200F41DB8 /* RealmSwift */; };
 		DAACFF042C244BDC00763006 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = DAACFF032C244BDC00763006 /* RxCocoa */; };
@@ -253,7 +253,6 @@
 		7B7E7C712C2577F0004AFA89 /* C.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = C.swift; sourceTree = "<group>"; };
 		7B7E7C732C2577F3004AFA89 /* D.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = D.swift; sourceTree = "<group>"; };
 		7B7E7C752C257802004AFA89 /* E.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = E.swift; sourceTree = "<group>"; };
-		7B7E7C772C25780D004AFA89 /* I.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I.swift; sourceTree = "<group>"; };
 		7B7E7C792C257810004AFA89 /* H.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = H.swift; sourceTree = "<group>"; };
 		7B7E7C7B2C257813004AFA89 /* G.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = G.swift; sourceTree = "<group>"; };
 		7B7E7C7D2C257816004AFA89 /* F.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = F.swift; sourceTree = "<group>"; };
@@ -306,6 +305,7 @@
 		7BF5CC3B2A53DD0600E4EE11 /* PostUIButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostUIButton.swift; sourceTree = "<group>"; };
 		7BFD09BE2A21E6E400B40054 /* FixedMenuTableResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedMenuTableResponse.swift; sourceTree = "<group>"; };
 		7BFD09C02A21EE3E00B40054 /* HomeRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRouter.swift; sourceTree = "<group>"; };
+		DA13BC9E2C26A7BF0083244A /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
 		DA5F4B6F2C192CA8009469C4 /* BaseUINavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseUINavigationBar.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -750,7 +750,7 @@
 		7B7E7C682C257708004AFA89 /* Auth */ = {
 			isa = PBXGroup;
 			children = (
-				7B7E7C772C25780D004AFA89 /* I.swift */,
+				DA13BC9E2C26A7BF0083244A /* View.swift */,
 			);
 			path = Auth;
 			sourceTree = "<group>";
@@ -1175,6 +1175,7 @@
 				7B9999252A8C03320043C592 /* String.swift in Sources */,
 				057A0B312A273DDF00F10B85 /* MoyaPluggin.swift in Sources */,
 				057A0B252A22284400F10B85 /* SignResponse.swift in Sources */,
+				DA13BC9F2C26A7BF0083244A /* View.swift in Sources */,
 				7B51C5A12A6322D60016B418 /* DataTypeProtocol.swift in Sources */,
 				057A0AC72A1B488B00F10B85 /* TotalReviewResponse.swift in Sources */,
 				057A0B212A22278800F10B85 /* RealmService.swift in Sources */,
@@ -1240,7 +1241,6 @@
 				052555B82C0DEB7400D38E34 /* DeleteAccountConfirmationView.swift in Sources */,
 				7B7E7C702C2577ED004AFA89 /* B.swift in Sources */,
 				056956FD29CB7958002E8CF2 /* ReviewTableCell.swift in Sources */,
-				7B7E7C782C25780D004AFA89 /* I.swift in Sources */,
 				7B203D3B2B0A1AE700059512 /* ProvisionView.swift in Sources */,
 				056956FF29CB81E2002E8CF2 /* SetRateViewController.swift in Sources */,
 				7B9998EB2A8279FC0043C592 /* HomeTimeTabmanController.swift in Sources */,

--- a/EatSSU-iOS/Migration/Source/Presentation/Auth/I.swift
+++ b/EatSSU-iOS/Migration/Source/Presentation/Auth/I.swift
@@ -1,8 +1,0 @@
-//
-//  File.swift
-//  EAT-SSU
-//
-//  Created by 최지우 on 6/21/24.
-//
-
-import Foundation

--- a/EatSSU-iOS/Migration/Source/Presentation/Auth/SubViews/View/MigratedSetNickNameView.swift
+++ b/EatSSU-iOS/Migration/Source/Presentation/Auth/SubViews/View/MigratedSetNickNameView.swift
@@ -1,0 +1,191 @@
+//
+//  MigratedSetNickNameView.swift
+//  EAT-SSU
+//
+//  Created by Jiwoong CHOI on 6/22/24.
+//
+
+import SnapKit
+import Then
+import UIKit
+
+final class MigratedSetNickNameView: BaseUIView {
+
+  // MARK: - Properties
+
+  private var userNickname: String = ""
+
+  // MARK: - UI Components
+
+  private let nickNameLabel = UILabel().then {
+    $0.text = TextLiteral.Auth.inputNickNameLabel
+    $0.font = .bold(size: 16)
+  }
+
+  let inputNickNameTextField = UITextField().then {
+    $0.placeholder = TextLiteral.Auth.inputNickName
+    $0.font = .regular(size: 12)
+    $0.textColor = .black
+    $0.setRoundBorder()
+    $0.addLeftPadding()
+    $0.clearButtonMode = .whileEditing
+  }
+
+  var nicknameDoubleCheckButton = PostUIButton().then {
+    $0.setRoundBorder(borderColor: .gray300, borderWidth: 0, cornerRadius: 10)
+    $0.addTitleAttribute(title: "중복 확인", titleColor: .white, fontName: .bold(size: 14))
+    $0.isEnabled = false
+  }
+
+  var nicknameValidationMessageLabel = UILabel().then {
+    $0.text = TextLiteral.Auth.hintInputNickName
+    $0.textColor = .gray700
+    $0.font = .semiBold(size: 12)
+  }
+
+  private lazy var setNickNameStackView: UIStackView = UIStackView(arrangedSubviews: [
+    inputNickNameTextField,
+    nicknameValidationMessageLabel,
+  ]).then {
+    $0.axis = .vertical
+    $0.spacing = 8.0
+  }
+
+  var completeSettingNickNameButton = PostUIButton().then {
+    $0.addTitleAttribute(
+      title: TextLiteral.Auth.completeLabel, titleColor: .white, fontName: .semiBold(size: 18))
+    $0.setRoundBorder(borderColor: .gray300, borderWidth: 0, cornerRadius: 10)
+    $0.isEnabled = false
+  }
+
+  // MARK: - init
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setTextFieldDelegate()
+  }
+
+  // MARK: Functions
+
+  override func configureUI() {
+    self.addSubviews(
+      nickNameLabel,
+      setNickNameStackView,
+      completeSettingNickNameButton,
+      nicknameDoubleCheckButton)
+  }
+
+  override func setLayout() {
+    nickNameLabel.snp.makeConstraints {
+      $0.top.equalTo(safeAreaLayoutGuide).offset(20)
+      $0.leading.equalToSuperview().inset(16)
+    }
+    setNickNameStackView.snp.makeConstraints {
+      $0.top.equalTo(nickNameLabel.snp.bottom).offset(16)
+      $0.leading.equalToSuperview().inset(16)
+      $0.trailing.equalTo(nicknameDoubleCheckButton.snp.leading).offset(-5)
+    }
+    nicknameDoubleCheckButton.snp.makeConstraints {
+      $0.top.equalTo(inputNickNameTextField)
+      $0.width.equalTo(75)
+      $0.height.equalTo(48)
+      $0.trailing.equalToSuperview().inset(16)
+    }
+    inputNickNameTextField.snp.makeConstraints {
+      $0.height.equalTo(48)
+    }
+    completeSettingNickNameButton.snp.makeConstraints {
+      $0.horizontalEdges.equalToSuperview().inset(16)
+      $0.bottom.equalToSuperview().inset(24)
+      $0.height.equalTo(50)
+    }
+  }
+
+  func setTextFieldDelegate() {
+    inputNickNameTextField.delegate = self
+  }
+
+}
+
+// MARK: - UITextFieldDelegate
+
+extension MigratedSetNickNameView: UITextFieldDelegate {
+
+  /// return 클릭 시, 키보드 내려감
+
+  func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+    textField.resignFirstResponder()
+    return true
+  }
+
+  /// textFiled 유효성 검사
+
+  func textFieldDidChangeSelection(_ textField: UITextField) {
+
+    guard let inputValue = textField.text?.trimmingCharacters(in: .whitespaces) else { return }
+
+    if inputValue.isEmpty {
+      textFieldSettingWhenEmpty(textField)
+      return
+    }
+    checkNicknameValidation(textField)
+  }
+
+  /// clearButton delegate
+
+  func textFieldShouldClear(_ textField: UITextField) -> Bool {
+    nicknameDoubleCheckButton.isEnabled = false
+    completeSettingNickNameButton.isEnabled = false
+    return true
+  }
+
+}
+
+// MARK: - Validation userInfo
+
+extension MigratedSetNickNameView {
+
+  /// 입력 없는 경우
+
+  fileprivate func textFieldSettingWhenEmpty(_ textField: UITextField) {
+
+    nicknameValidationMessageLabel.text = NicknameTextFieldResultType.textFieldEmpty.hintMessage
+    nicknameValidationMessageLabel.textColor = NicknameTextFieldResultType.textFieldEmpty.textColor
+  }
+
+  /// 닉네임 형식 검사
+
+  fileprivate func checkNicknameValidation(_ textField: UITextField) {
+
+    if let userNickname = textField.text {
+      if nicknameInputChanged(nickname: userNickname) {
+        nicknameValidationMessageLabel.text =
+          NicknameTextFieldResultType.nicknameTextFieldDoubleCheck.hintMessage
+        nicknameValidationMessageLabel.textColor =
+          NicknameTextFieldResultType.nicknameTextFieldDoubleCheck.textColor
+      } else {
+        nicknameValidationMessageLabel.text =
+          NicknameTextFieldResultType.nicknameTextFieldOver.hintMessage
+        nicknameValidationMessageLabel.textColor =
+          NicknameTextFieldResultType.nicknameTextFieldOver.textColor
+      }
+    }
+  }
+
+  /// Input 변경 시
+
+  fileprivate func nicknameInputChanged(nickname: String) -> Bool {
+
+    /// 텍스트 변경 시, 완료하기 버튼 false 처리
+    completeSettingNickNameButton.isEnabled = false
+
+    if nickname.count > 1 && nickname.count < 9 {
+      nicknameDoubleCheckButton.isEnabled = true
+      return true
+    } else {
+      nicknameDoubleCheckButton.isEnabled = false
+      return false
+    }
+  }
+
+}

--- a/EatSSU-iOS/Migration/Source/Presentation/Auth/SubViews/View/MigratedSetNickNameViewController.swift
+++ b/EatSSU-iOS/Migration/Source/Presentation/Auth/SubViews/View/MigratedSetNickNameViewController.swift
@@ -1,0 +1,188 @@
+//
+//  MigratedSetNickNameViewController.swift
+//  EAT-SSU
+//
+//  Created by Jiwoong CHOI on 6/22/24.
+//
+
+import Moya
+import Realm
+import SnapKit
+import Then
+import UIKit
+
+final class MigratedSetNickNameViewController: BaseViewController {
+  // MARK: - Properties
+
+  var currentKeyboardHeight: CGFloat = 0.0
+  private let nicknameProvider = MoyaProvider<UserNicknameRouter>(plugins: [MoyaLoggingPlugin()])
+
+  // MARK: - UI Components
+
+  private let setNickNameView = MigratedSetNickNameView()
+
+  // MARK: - Life Cycles
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    dismissKeyboard()
+  }
+
+  override func viewWillAppear(_ animated: Bool) {
+    self.addKeyboardNotifications()
+  }
+
+  override func viewWillDisappear(_ animated: Bool) {
+    self.removeKeyboardNotifications()
+  }
+
+  // MARK: - UI Configurations
+
+  override func configureUI() {
+    view.addSubviews(setNickNameView)
+  }
+
+  override func setLayout() {
+    setNickNameView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+  }
+
+  override func customNavigationBar() {
+    super.customNavigationBar()
+    navigationItem.title = TextLiteral.Auth.setNickName
+  }
+
+  override func setButtonEvent() {
+    setNickNameView.completeSettingNickNameButton.addTarget(
+      self, action: #selector(tappedCompleteNickNameButton), for: .touchUpInside)
+    setNickNameView.nicknameDoubleCheckButton.addTarget(
+      self, action: #selector(tappedCheckButton), for: .touchUpInside)
+  }
+
+  // MARK: - Button Action Methods
+
+  @objc
+  private func tappedCompleteNickNameButton() {
+    self.setUserNickname(nickname: self.setNickNameView.inputNickNameTextField.text ?? "")
+  }
+
+  @objc
+  private func tappedCheckButton() {
+    self.checkNickname(nickname: self.setNickNameView.inputNickNameTextField.text ?? "")
+  }
+
+  // MARK: - KeyBoard Methods
+
+  private func addKeyboardNotifications() {
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(self.keyboardWillShow(_:)),
+      name: UIResponder.keyboardWillShowNotification,
+      object: nil)
+    NotificationCenter.default.addObserver(
+      self, selector: #selector(self.keyboardWillHide(_:)),
+      name: UIResponder.keyboardWillHideNotification,
+      object: nil)
+  }
+
+  private func removeKeyboardNotifications() {
+    NotificationCenter.default.removeObserver(
+      self,
+      name: UIResponder.keyboardWillShowNotification,
+      object: nil)
+    NotificationCenter.default.removeObserver(
+      self,
+      name: UIResponder.keyboardWillHideNotification,
+      object: nil)
+  }
+
+  @objc
+  private func keyboardWillShow(_ notification: Notification) {
+    if let keyboardSize =
+      (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue
+    {
+      let updateKeyboardHeight = keyboardSize.height
+      let difference = updateKeyboardHeight - currentKeyboardHeight
+
+      setNickNameView.completeSettingNickNameButton.frame.origin.y -= difference
+      currentKeyboardHeight = updateKeyboardHeight
+    }
+  }
+
+  @objc
+  private func keyboardWillHide(_ notification: Notification) {
+    // 옵셔널 바인딩으로 인한 keyboardSize 상수는 사용되지 않아 경고 발생. 최초 작성자가 확인 후 공유.
+    if let keyboardSize =
+      (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue
+    {
+      setNickNameView.completeSettingNickNameButton.frame.origin.y += currentKeyboardHeight
+      currentKeyboardHeight = 0.0
+    }
+  }
+}
+
+// MARK: - Network
+
+extension MigratedSetNickNameViewController {
+  private func setUserNickname(nickname: String) {
+    self.nicknameProvider.request(.setNickname(nickname: nickname)) { response in
+      switch response {
+      case .success(let moyaResponse):
+        do {
+          self.showAlert(title: "완료", text: "닉네임 설정이 완료되었습니다.", style: .cancel) {
+            if let myPageViewController = self.navigationController?.viewControllers.first(
+              where: { $0 is MyPageViewController }
+            ) {
+              self.navigationController?.popToViewController(myPageViewController, animated: true)
+            } else {
+              let homeViewController = HomeViewController()
+              if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+                let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow })
+              {
+                keyWindow.replaceRootViewController(
+                  UINavigationController(rootViewController: homeViewController), animated: true,
+                  completion: nil)
+              }
+            }
+          }
+          debugPrint(moyaResponse.statusCode)
+        }
+      case .failure(let error):
+        debugPrint(error.localizedDescription)
+      }
+    }
+  }
+
+  private func checkNickname(nickname: String) {
+    self.nicknameProvider.request(.checkNickname(nickname: nickname)) { response in
+      switch response {
+      case .success(let moyaResponse):
+        do {
+          let responseData = try moyaResponse.map(BaseResponse<Bool>.self)
+          let isSuccess = responseData.result
+          if isSuccess {
+            self.view.showToast(message: "사용 가능한 닉네임이에요")
+            self.setNickNameView.completeSettingNickNameButton.isEnabled = isSuccess
+            self.setNickNameView.nicknameValidationMessageLabel.text =
+              NicknameTextFieldResultType.nicknameTextFieldValid.hintMessage
+            self.setNickNameView.nicknameValidationMessageLabel.textColor =
+              NicknameTextFieldResultType.nicknameTextFieldValid.textColor
+          } else {
+            self.view.showToast(message: "이미 사용 중인 닉네임이에요")
+            self.setNickNameView.completeSettingNickNameButton.isEnabled = isSuccess
+            self.setNickNameView.nicknameValidationMessageLabel.text =
+              NicknameTextFieldResultType.nicknameTextFieldDuplicated.hintMessage
+            self.setNickNameView.nicknameValidationMessageLabel.textColor =
+              NicknameTextFieldResultType.nicknameTextFieldDuplicated.textColor
+          }
+        } catch (let error) {
+          debugPrint(error.localizedDescription)
+        }
+      case .failure(let error):
+        debugPrint(error.localizedDescription)
+      }
+    }
+  }
+}

--- a/EatSSU-iOS/Migration/Source/Presentation/Auth/View.swift
+++ b/EatSSU-iOS/Migration/Source/Presentation/Auth/View.swift
@@ -1,8 +1,0 @@
-//
-//  View.swift
-//  EAT-SSU
-//
-//  Created by Jiwoong CHOI on 6/22/24.
-//
-
-import Foundation

--- a/EatSSU-iOS/Migration/Source/Presentation/Auth/View.swift
+++ b/EatSSU-iOS/Migration/Source/Presentation/Auth/View.swift
@@ -1,0 +1,8 @@
+//
+//  View.swift
+//  EAT-SSU
+//
+//  Created by Jiwoong CHOI on 6/22/24.
+//
+
+import Foundation

--- a/EatSSU-iOS/Migration/Source/Presentation/Auth/View/MigratedLoginView.swift
+++ b/EatSSU-iOS/Migration/Source/Presentation/Auth/View/MigratedLoginView.swift
@@ -1,0 +1,60 @@
+//
+//  MigratedLoginView.swift
+//  EAT-SSU
+//
+//  Created by Jiwoong CHOI on 6/22/24.
+//
+
+import SnapKit
+import Then
+import UIKit
+
+final class MigratedLoginView: BaseUIView {
+
+  // MARK: - UI Components
+
+  private let logoImage = UIImageView().then { $0.image = ImageLiteral.Auth.signInImage }
+
+  let appleLoginButton = UIButton().then {
+    $0.setImage(ImageLiteral.Auth.appleLoginButton, for: .normal)
+  }
+
+  let kakaoLoginButton = UIButton().then {
+    $0.setImage(ImageLiteral.Auth.kakaoLoginButton, for: .normal)
+  }
+
+  let lookingWithNoSignInButton = UIButton().then {
+    $0.setImage(ImageLiteral.Auth.lookingButton, for: .normal)
+  }
+
+  override func configureUI() {
+    self.addSubviews(
+      logoImage,
+      appleLoginButton,
+      kakaoLoginButton,
+      lookingWithNoSignInButton)
+  }
+
+  override func setLayout() {
+    logoImage.snp.makeConstraints {
+      $0.top.equalToSuperview()
+      $0.horizontalEdges.equalToSuperview().inset(90)
+      $0.height.equalTo(194)
+    }
+    appleLoginButton.snp.makeConstraints {
+      $0.bottom.equalTo(safeAreaLayoutGuide).inset(100)
+      $0.horizontalEdges.equalToSuperview().inset(20)
+      $0.height.equalTo(60)
+    }
+    kakaoLoginButton.snp.makeConstraints {
+      $0.top.equalTo(appleLoginButton.snp.bottom)
+      $0.horizontalEdges.equalToSuperview().inset(20)
+      $0.height.equalTo(60)
+    }
+    lookingWithNoSignInButton.snp.makeConstraints {
+      $0.top.equalTo(kakaoLoginButton.snp.bottom).offset(10)
+      $0.horizontalEdges.equalToSuperview().inset(20)
+      $0.height.equalTo(45)
+    }
+  }
+}

--- a/EatSSU-iOS/Migration/Source/Presentation/Auth/View/MigratedLoginViewController.swift
+++ b/EatSSU-iOS/Migration/Source/Presentation/Auth/View/MigratedLoginViewController.swift
@@ -1,0 +1,295 @@
+//
+//  MigratedLoginViewController.swift
+//  EAT-SSU
+//
+//  Created by Jiwoong CHOI on 6/22/24.
+//
+
+import AuthenticationServices
+import Firebase
+import KakaoSDKUser
+import Moya
+import RealmSwift
+import SnapKit
+import Then
+import UIKit
+
+final class MigratedLoginViewController: BaseViewController {
+  // MARK: - Properties
+
+  var loginAfterlooking = true
+
+  // MARK: - UI Components
+
+  private let loginView = MigratedLoginView()
+  private let authProvider = MoyaProvider<AuthRouter>(plugins: [MoyaLoggingPlugin()])
+  private let myProvider = MoyaProvider<MyRouter>(plugins: [MoyaLoggingPlugin()])
+
+  // MARK: - Life Cycles
+
+  override func viewWillAppear(_ animated: Bool) {
+    super.viewWillAppear(animated)
+
+    self.checkUser()
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    Analytics.logEvent("LoginViewControllerLoad", parameters: nil)
+  }
+
+  // MARK: - UI Configuration
+
+  override func configureUI() {
+    view.addSubviews(loginView)
+  }
+
+  override func setLayout() {
+    loginView.snp.makeConstraints {
+      $0.top.equalToSuperview().offset(UIScreen.main.bounds.height / 4.0)
+      $0.leading.trailing.equalToSuperview()
+      $0.bottom.equalTo(view.safeAreaLayoutGuide.snp.bottomMargin).inset(50)
+    }
+  }
+
+  override func setButtonEvent() {
+    loginView.kakaoLoginButton.addTarget(
+      self, action: #selector(kakaoLoginButtonDidTapped), for: .touchUpInside)
+    loginView.appleLoginButton.addTarget(
+      self, action: #selector(appleLoginButtonDidTapped), for: .touchUpInside)
+    loginView.lookingWithNoSignInButton.addTarget(
+      self, action: #selector(lookingWithNoSignInButtonDidTapped), for: .touchUpInside)
+  }
+
+  // MARK: - Some Methods
+
+  private func getUserInfo() {
+    UserApi.shared.me { user, error in
+      if let error = error {
+        debugPrint("🎃", error.localizedDescription)
+      } else {
+        guard let email = user?.kakaoAccount?.email else { return }
+        guard let id = user?.id else { return }
+        self.postKakaoLoginRequest(email: email, id: String(id))
+      }
+    }
+  }
+
+  private func addTokenInRealm(accessToken: String, refreshToken: String) {
+    RealmService.shared.addToken(accessToken: accessToken, refreshToken: refreshToken)
+    debugPrint("⭐️⭐️토큰 저장 성공~⭐️⭐️")
+    debugPrint(RealmService.shared.getToken())
+    debugPrint(RealmService.shared.getRefreshToken())
+  }
+
+  private func pushToHomeVC() {
+    let homeVC = HomeViewController()
+
+    if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+      let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow })
+    {
+      keyWindow.replaceRootViewController(
+        UINavigationController(rootViewController: homeVC), animated: true, completion: nil)
+    }
+  }
+
+  private func pushToNicknameVC() {
+    let setNicknameViewController = SetNickNameViewController()
+    navigationController?.pushViewController(setNicknameViewController, animated: true)
+  }
+
+  private func checkRealmToken() -> Bool {
+    if RealmService.shared.getToken() == "" {
+      return false
+    } else {
+      return true
+    }
+  }
+
+  private func checkUser() {
+    /// 자동 로그인 풀고 싶을 때 한번 실행시켜주기
+    //        self.realm.resetDB()
+
+    /// 자동 로그인
+    if self.checkRealmToken() {
+      debugPrint(RealmService.shared.getToken())
+      self.pushToHomeVC()
+    }
+  }
+
+  /// 요청으로 얻을 수 있는 값들: 이름, 이메일로 설정
+  private func appleLoginRequest() {
+    let appleIDProvider = ASAuthorizationAppleIDProvider()
+    let request = appleIDProvider.createRequest()
+    request.requestedScopes = [.fullName, .email]
+
+    let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+    authorizationController.delegate = self
+    authorizationController.presentationContextProvider = self
+    authorizationController.performRequests()
+  }
+
+  private func checkUserNickname(info: MyInfoResponse) {
+    switch info.nickname {
+    case nil:
+      self.pushToNicknameVC()
+    default:
+      self.pushToHomeVC()
+    }
+  }
+
+  // MARK: - Button Action Methods
+
+  @objc
+  func kakaoLoginButtonDidTapped() {
+    // 카카오톡 앱이 설치되어 있는지 확인
+    if UserApi.isKakaoTalkLoginAvailable() {
+      // 카카오톡 앱을 통한 로그인 시도
+      UserApi.shared.loginWithKakaoTalk { oauthToken, error in
+        if let error = error {
+          debugPrint(error)
+        } else {
+          debugPrint("loginWithKakaoTalk() success.")
+          self.getUserInfo()
+          _ = oauthToken
+        }
+      }
+    } else {
+      // 카카오 계정을 통한 웹 로그인 시도
+      UserApi.shared.loginWithKakaoAccount { oauthToken, error in
+        if let error = error {
+          debugPrint(error)
+        } else {
+          self.getUserInfo()
+          _ = oauthToken
+        }
+      }
+    }
+  }
+
+  @objc
+  private func appleLoginButtonDidTapped() {
+    appleLoginRequest()
+  }
+
+  @objc
+  func lookingWithNoSignInButtonDidTapped() {
+    pushToHomeVC()
+  }
+}
+
+// MARK: - Network
+
+extension MigratedLoginViewController {
+  func postKakaoLoginRequest(email: String, id: String) {
+    self.authProvider.request(
+      .kakaoLogin(
+        param: KakaoLoginRequest(
+          email: email,
+          providerId: id
+        )
+      )
+    ) { response in
+      switch response {
+      case .success(let moyaResponse):
+        do {
+          debugPrint(moyaResponse.statusCode)
+          let responseData = try moyaResponse.map(BaseResponse<SignResponse>.self)
+          self.addTokenInRealm(
+            accessToken: responseData.result.accessToken,
+            refreshToken: responseData.result.refreshToken)
+          self.getMyInfo()
+        } catch (let err) {
+          self.presentBottomAlert(err.localizedDescription)
+          debugPrint(err.localizedDescription)
+        }
+      case .failure(let err):
+        self.presentBottomAlert(err.localizedDescription)
+        debugPrint(err.localizedDescription)
+      }
+    }
+  }
+
+  private func getMyInfo() {
+    self.myProvider.request(.myInfo) { response in
+      switch response {
+      case .success(let moyaResponse):
+        do {
+          let responseData = try moyaResponse.map(BaseResponse<MyInfoResponse>.self)
+          self.checkUserNickname(info: responseData.result)
+        } catch (let err) {
+          debugPrint(err.localizedDescription)
+        }
+      case .failure(let err):
+        debugPrint(err.localizedDescription)
+      }
+    }
+  }
+
+  private func postAppleLoginRequest(token: String) {
+    self.authProvider.request(.appleLogin(param: AppleLoginRequest(identityToken: token))) {
+      response in
+      switch response {
+      case .success(let moyaResponse):
+        do {
+          debugPrint(moyaResponse.statusCode)
+          let responseData = try moyaResponse.map(BaseResponse<SignResponse>.self)
+          self.addTokenInRealm(
+            accessToken: responseData.result.accessToken,
+            refreshToken: responseData.result.refreshToken
+          )
+          self.getMyInfo()
+        } catch (let err) {
+          self.presentBottomAlert(err.localizedDescription)
+          debugPrint(err.localizedDescription)
+        }
+      case .failure(let err):
+        self.presentBottomAlert(err.localizedDescription)
+        debugPrint(err.localizedDescription)
+      }
+    }
+  }
+}
+
+extension MigratedLoginViewController: ASAuthorizationControllerPresentationContextProviding,
+  ASAuthorizationControllerDelegate
+{
+  func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+    return self.view.window!
+  }
+
+  // Apple ID 연동 성공 시
+  func authorizationController(
+    controller: ASAuthorizationController,
+    didCompleteWithAuthorization authorization: ASAuthorization
+  ) {
+    switch authorization.credential {
+    // Apple ID
+    case let appleIDCredential as ASAuthorizationAppleIDCredential:
+
+      // 계정 정보 가져오기
+      let userIdentifier = appleIDCredential.user
+      let fullName = appleIDCredential.fullName
+      let email = appleIDCredential.email
+      let idToken = appleIDCredential.identityToken!
+      let tokeStr = String(data: idToken, encoding: .utf8)
+
+      self.postAppleLoginRequest(token: tokeStr ?? "")
+      debugPrint("User ID : \(userIdentifier)")
+      debugPrint("User Email : \(email ?? "")")
+      debugPrint("User Name : \((fullName?.givenName ?? "") + (fullName?.familyName ?? ""))")
+      debugPrint("token : \(String(describing: tokeStr))")
+
+    default:
+      break
+    }
+  }
+
+  // Apple ID 연동 실패 시
+  func authorizationController(
+    controller: ASAuthorizationController, didCompleteWithError error: Error
+  ) {
+    debugPrint("Login in Fail.")
+  }
+}


### PR DESCRIPTION
## 🔆 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 마이페이지와 같은 맥락으로 소스코드에 대한 수정은 없습니다.
- MVVM의 View 계층에 적합하도록 설계를 완료했습니다.

## 💡 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- View 계층의 구조를 집중적으로 보았으면 합니다.
- 마이페이지과 같은 맥락으로 Auth 영역 아래에 Login으로 이름이 한 번 달라지는데, 이 부분을 통일화 하고 싶습니다. 의견 달아주세요!

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

![Screenshot 2024-06-22 at 18 18 20](https://github.com/EAT-SSU/EATSSU-iOS/assets/82222245/3009c51e-ef91-4cba-acf4-3a89f59cf319)

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #14 .
