### PR TITLE
[#21] RequestViewModel 설계 완료

### DIFF
--- a/EatSSU-iOS/EatSSU-iOS.xcodeproj/project.pbxproj
+++ b/EatSSU-iOS/EatSSU-iOS.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 		DA744B4A2C2EB03300B67986 /* MigratedReviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA744B492C2EB03300B67986 /* MigratedReviewViewModel.swift */; };
 		DA83B3E82C18587200F41DB8 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = DA83B3E72C18587200F41DB8 /* RealmSwift */; };
 		DA85BDCD2C2F8A5900AB5B52 /* MigratedProvisionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA85BDCC2C2F8A5900AB5B52 /* MigratedProvisionViewModel.swift */; };
+		DA85BDD02C2F8F6900AB5B52 /* MigratedRequestViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA85BDCF2C2F8F6900AB5B52 /* MigratedRequestViewModel.swift */; };
 		DAACFF042C244BDC00763006 /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = DAACFF032C244BDC00763006 /* RxCocoa */; };
 		DAACFF062C244BDC00763006 /* RxSwift in Frameworks */ = {isa = PBXBuildFile; productRef = DAACFF052C244BDC00763006 /* RxSwift */; };
 		DAC1DF692C18FE6F00AEDDD3 /* SwiftFormat in Frameworks */ = {isa = PBXBuildFile; productRef = DAC1DF682C18FE6F00AEDDD3 /* SwiftFormat */; };
@@ -351,6 +352,7 @@
 		DA6F04062C2D928600827EC7 /* MigratedMyPageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MigratedMyPageViewController.swift; sourceTree = "<group>"; };
 		DA744B492C2EB03300B67986 /* MigratedReviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigratedReviewViewModel.swift; sourceTree = "<group>"; };
 		DA85BDCC2C2F8A5900AB5B52 /* MigratedProvisionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigratedProvisionViewModel.swift; sourceTree = "<group>"; };
+		DA85BDCF2C2F8F6900AB5B52 /* MigratedRequestViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigratedRequestViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1187,6 +1189,7 @@
 			isa = PBXGroup;
 			children = (
 				DA6F03FE2C2D928600827EC7 /* View */,
+				DA85BDCE2C2F8F5600AB5B52 /* ViewModel */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -1246,6 +1249,15 @@
 				DA85BDCC2C2F8A5900AB5B52 /* MigratedProvisionViewModel.swift */,
 			);
 			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		DA85BDCE2C2F8F5600AB5B52 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				DA85BDCF2C2F8F6900AB5B52 /* MigratedRequestViewModel.swift */,
+			);
+			name = ViewModel;
+			path = "New Group";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1460,6 +1472,7 @@
 				DA363FE42C2E286E007EF64F /* MigratedSetNicknameViewModel.swift in Sources */,
 				7B9998F32A836E660043C592 /* RestaurantTableViewHeader.swift in Sources */,
 				7B2BBFB4299A29DC00EE0F1F /* UIViewController+.swift in Sources */,
+				DA85BDD02C2F8F6900AB5B52 /* MigratedRequestViewModel.swift in Sources */,
 				7B2C9E9B29DF3B4A0007603D /* ImageLiteral.swift in Sources */,
 				DA3640202C2E5CF0007EF64F /* MyReviewViewController.swift in Sources */,
 				0540F10E2B7A08790075C7B0 /* BaseResponse.swift in Sources */,

--- a/EatSSU-iOS/Migration/Source/Presentation/MyPage/SubViews/Request/New Group/MigratedRequestViewModel.swift
+++ b/EatSSU-iOS/Migration/Source/Presentation/MyPage/SubViews/Request/New Group/MigratedRequestViewModel.swift
@@ -1,0 +1,32 @@
+//
+//  MigratedRequestViewModel.swift
+//  EAT-SSU
+//
+//  Created by Jiwoong CHOI on 6/29/24.
+//
+
+import Foundation
+import Moya
+
+class MigratedRequestViewModel {
+  private let myProvider = MoyaProvider<MyRouter>(plugins: [MoyaLoggingPlugin()])
+
+  public func postInquiry(email: String, content: String, completion : @escaping () -> Void) {
+    let param = InquiryRequest(email, content)
+    self.myProvider.request(.inquiry(param: param)) { response in
+      switch response {
+      case .success(let moyaResponse):
+        do {
+          let responseData = try moyaResponse.map(BaseResponse<Bool>.self)
+          debugPrint(responseData)
+          completion()
+        } catch (let err) {
+          debugPrint(err.localizedDescription)
+          completion()
+        }
+      case .failure(let err):
+        print(err.localizedDescription)
+      }
+    }
+  }
+}

--- a/EatSSU-iOS/Migration/Source/Presentation/MyPage/SubViews/Request/View/MigratedRequestViewController.swift
+++ b/EatSSU-iOS/Migration/Source/Presentation/MyPage/SubViews/Request/View/MigratedRequestViewController.swift
@@ -10,48 +10,48 @@ import SnapKit
 import Then
 import UIKit
 
-final class MigratedRequestViewController: BaseViewController {
+final class MigratedRequestViewController: BaseViewController, UITextViewDelegate {
   // MARK: - Properties
-
-  private let myProvider = MoyaProvider<MyRouter>(plugins: [MoyaLoggingPlugin()])
-
+  
+  private var viewModel = MigratedRequestViewModel()
+  
   // MARK: - UI Component
-
+  
   private let requestView = MigratedRequestView()
-
+  
   // MARK: - Life Cycles
-
+  
   override func viewDidLoad() {
     super.viewDidLoad()
     self.setDelegate()
-
+    
     dismissKeyboard()
   }
-
+  
   // MARK: - UI Configuration
-
+  
   override func configureUI() {
     self.view.addSubview(requestView)
   }
-
+  
   override func setLayout() {
     requestView.snp.makeConstraints {
       $0.edges.equalToSuperview()
     }
   }
-
+  
   override func setButtonEvent() {
     requestView.sendButton.addTarget(self, action: #selector(sendButtonDidTap), for: .touchUpInside)
   }
-
+  
   private func setDelegate() {
     requestView.contentTextView.delegate = self
   }
-
+  
   // MARK: - Button Action Methods
-
+  
   @objc
-  private func sendButtonDidTap() {
+  func sendButtonDidTap() {
     if requestView.contentTextView.text == "여기에 내용을 작성해주세요." {
       view.showToast(message: "문의 내용을 작성해주세요!")
     } else if requestView.contentTextView.text?.count ?? 0 < 5 {
@@ -61,46 +61,49 @@ final class MigratedRequestViewController: BaseViewController {
     {
       view.showToast(message: "이메일 주소를 남겨주세요!")
     } else {
-      postInquiry(
+      viewModel.postInquiry(
         email: requestView.emailTextField.text ?? "",
-        content: requestView.contentTextView.text)
+        content: requestView.contentTextView.text ?? "")
+      {
+        self.showSuccessAlert()
+      }
     }
   }
 
   // MARK: - Some Methods
-
+    
   private func isTextFieldEmpty(email: String) -> Bool {
     guard let inputValue = requestView.emailTextField.text?.trimmingCharacters(in: .whitespaces)
     else { return true }
-
+      
     if inputValue.isEmpty {
       return true
     } else {
       return false
     }
   }
-
+    
   private func showSuccessAlert() {
     let alert = UIAlertController(
       title: "문의 완료",
       message: "문의 내용이 성공적으로 접수되었어요!",
       preferredStyle: UIAlertController.Style.alert)
-
+      
     let okAction = UIAlertAction(
       title: "마이페이지로 돌아가기",
       style: .default,
       handler: { _ in
         self.navigationController?.popViewController(animated: true)
       })
-
+      
     alert.addAction(okAction)
     present(alert, animated: true, completion: nil)
   }
 }
-
+  
 // MARK: - UITextView Delegate
-
-extension MigratedRequestViewController: UITextViewDelegate {
+  
+extension MigratedRequestViewController {
   func textView(
     _ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String
   ) -> Bool {
@@ -111,41 +114,18 @@ extension MigratedRequestViewController: UITextViewDelegate {
     }
     return true
   }
-
+    
   func textViewDidBeginEditing(_ textView: UITextView) {
     if textView.text == "여기에 내용을 작성해주세요." {
       textView.text = ""
       textView.textColor = .black
     }
   }
-
+    
   func textViewDidEndEditing(_ textView: UITextView) {
     if textView.text.isEmpty {
       textView.text = "여기에 내용을 작성해주세요."
       textView.textColor = .gray500
-    }
-  }
-}
-
-// MARK: - Server
-
-extension MigratedRequestViewController {
-  private func postInquiry(email: String, content: String) {
-    let param = InquiryRequest(email, content)
-    self.myProvider.request(.inquiry(param: param)) { response in
-      switch response {
-      case .success(let moyaResponse):
-        do {
-          let responseData = try moyaResponse.map(BaseResponse<Bool>.self)
-          print(responseData)
-          self.showSuccessAlert()
-        } catch (let err) {
-          print(err.localizedDescription)
-          self.showSuccessAlert()
-        }
-      case .failure(let err):
-        print(err.localizedDescription)
-      }
     }
   }
 }


### PR DESCRIPTION
## 🔆 개요

<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->

- 네트워크 비즈니스 로직을 분리했습니다.
- 마지막 ViewModel을 설계하면서 느끼는 것이지만, 클라이언트 사이드 비즈니스 로직이 복잡하지 않아서 주로 네트워크쪽 로직을 분리하는 부분만 **관심사 분리** 원칙이 가장 중심인 것 같습니다.
- 단순히 ViewModel을 만드는 것만 생각하면 복잡하지 않은 우리 팀의 코드에서는 **함수타입** 프로퍼티나 **완료 핸들러**를 사용해서 구현할 수 있다고 생각합니다.
- Combine이나 RxSwift 프레임워크를 사용하면 오히려 선언적 프로그래밍에 더 중점을 두어야 하지 않을까 하는 생각이네요.

## 💡 PR Point

<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->

- 없습니다.

## 📷 스크린샷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

- 없습니다.

## 📮 관련 이슈

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- Resolved: #21 .
